### PR TITLE
Add a leftout syn edit

### DIFF
--- a/2013/ts-syntactical.json
+++ b/2013/ts-syntactical.json
@@ -9,6 +9,15 @@
         }
     },
     {
+        "id": "S013",
+        "description": "Timestamp must be later than timestamp on database.",
+        "rule": {
+            "property": "timestamp",
+            "condition": "call",
+            "function": "isTimestampLaterThanDatabase"
+        }
+    },
+    {
         "id": "S028",
         "description": "Timestamp must be numeric and in ccyymmddhhmm format.",
         "rule": {

--- a/2014/ts-syntactical.json
+++ b/2014/ts-syntactical.json
@@ -9,6 +9,15 @@
         }
     },
     {
+        "id": "S013",
+        "description": "Timestamp must be later than timestamp on database.",
+        "rule": {
+            "property": "timestamp",
+            "condition": "call",
+            "function": "isTimestampLaterThanDatabase"
+        }
+    },
+    {
         "id": "S028",
         "description": "Timestamp must be numeric and in ccyymmddhhmm format.",
         "rule": {


### PR DESCRIPTION
I initially left out this syntactical edit because it had a custom call. Adding it now.
