### PR TITLE
Macro fixes

### DIFF
--- a/2013/hmda-macro.json
+++ b/2013/hmda-macro.json
@@ -24,8 +24,11 @@
                     "condition": "equal",
                     "value": "3"
                 },
-                "less_than",
-                "200"
+                {
+                    "property": "result",
+                    "condition": "less_than",
+                    "value": "200"
+                }
             ]
         }
     },
@@ -54,8 +57,11 @@
                             }
                         ]
                     },
-                    "greater_than",
-                    "25"
+                    {
+                        "property": "result",
+                        "condition": "greater_than",
+                        "value": "25"
+                    }
                 ]
             },
             "then": {
@@ -83,8 +89,11 @@
                         "condition": "equal",
                         "value": "1"
                     },
-                    "less_than_or_equal",
-                    ".95"
+                    {
+                        "property": "result",
+                        "condition": "less_than_or_equal",
+                        "value": ".95"
+                    }
                 ]
             }
         }
@@ -118,8 +127,11 @@
                     "condition": "equal",
                     "value": "2"
                 },
-                "less_than_or_equal",
-                ".1"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".1"
+                }
             ]
         }
     },

--- a/2013/hmda-macro.json
+++ b/2013/hmda-macro.json
@@ -164,8 +164,11 @@
                     "condition": "equal",
                     "value": "2"
                 },
-                "less_than_or_equal",
-                ".05"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".05"
+                }
             ]
         }
     },
@@ -189,8 +192,11 @@
                     "condition": "equal",
                     "value": "2"
                 },
-                "less_than_or_equal",
-                ".15"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".15"
+                }
             ]
         }
     },
@@ -214,8 +220,11 @@
                     "condition": "equal",
                     "value": "2"
                 },
-                "less_than_or_equal",
-                ".30"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".30"
+                }
             ]
         }
     },
@@ -239,8 +248,11 @@
                     "condition": "equal",
                     "value": "2"
                 },
-                "less_than_or_equal",
-                ".15"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".15"
+                }
             ]
         }
     },
@@ -264,8 +276,11 @@
                     "condition": "in",
                     "values": ["1", "2", "3", "4", "5", "6"]
                 },
-                "greater_than_or_equal",
-                ".20"
+                {
+                    "property": "result",
+                    "condition": "greater_than_or_equal",
+                    "value": ".20"
+                }
             ]
         }
     },
@@ -289,8 +304,11 @@
                     "condition": "equal",
                     "value": "2"
                 },
-                "less_than_or_equal",
-                ".30"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".30"
+                }
             ]
         }
     },
@@ -324,8 +342,11 @@
                     "condition": "equal",
                     "value": "2"
                 },
-                "less_than_or_equal",
-                ".20"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".20"
+                }
             ]
         }
     },
@@ -363,8 +384,11 @@
                     "condition": "equal",
                     "value": "1"
                 },
-                "less_than_or_equal",
-                ".01"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".01"
+                }
             ]
         }
     },
@@ -402,8 +426,11 @@
                     "condition": "equal",
                     "value": "6"
                 },
-                "less_than_or_equal",
-                ".01"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".01"
+                }
             ]
         }
     },
@@ -446,8 +473,11 @@
                     "condition": "equal",
                     "value": "1"
                 },
-                "less_than_or_equal",
-               ".01"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".01"
+                }
             ]
         }
     },
@@ -490,8 +520,11 @@
                     "condition": "equal",
                     "value": "1"
                 },
-                "less_than_or_equal",
-                ".01"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".01"
+                }
             ]
         }
     },
@@ -510,8 +543,11 @@
                     "condition": "equal",
                     "value": "1"
                 },
-                "less_than",
-                "200"
+                {
+                    "property": "result",
+                    "condition": "less_than",
+                    "value": "200"
+                }
             ]
         }
     },
@@ -558,8 +594,11 @@
                     "condition": "equal",
                     "value": "1"
                 },
-                "less_than_or_equal",
-                ".05"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".05"
+                }
             ]
         }
     },
@@ -611,8 +650,11 @@
                     "condition": "equal",
                     "value": "1"
                 },
-                "less_than_or_equal",
-                ".01"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".01"
+                }
             ]
         }
     },
@@ -641,8 +683,11 @@
                             }
                         ]
                     },
-                    "greater_than_or_equal",
-                    "50"
+                    {
+                        "property": "result",
+                        "condition": "greater_than_or_equal",
+                        "value": "50"
+                    }
                 ]
             },
             "then": {
@@ -684,8 +729,11 @@
                             }
                         ]
                     },
-                    "less_than_or_equal",
-                    ".70"
+                    {
+                        "property": "result",
+                        "condition": "less_than_or_equal",
+                        "value": ".70"
+                    }
                 ]
             }
         }
@@ -706,8 +754,11 @@
                         "condition": "equal",
                         "value": "2"
                     },
-                    "greater_than_or_equal",
-                    "50"
+                    {
+                        "property": "result",
+                        "condition": "greater_than_or_equal",
+                        "value": "50"
+                    }
                 ]
             },
             "then": {
@@ -721,8 +772,11 @@
                         "condition": "equal",
                         "value": "3"
                     },
-                    "greater_than",
-                    "0"
+                    {
+                        "property": "result",
+                        "condition": "greater_than",
+                        "value": "0"
+                    }
                 ]
             }
         }
@@ -743,8 +797,11 @@
                         "condition": "equal",
                         "value": "1"
                     },
-                    "greater_than_or_equal",
-                    "1000"
+                    {
+                        "property": "result",
+                        "condition": "greater_than_or_equal",
+                        "value": "1000"
+                    }
                 ]
             },
             "then": {
@@ -758,8 +815,11 @@
                         "condition": "equal",
                         "value": "7"
                     },
-                    "greater_than",
-                    "0"
+                    {
+                        "property": "result",
+                        "condition": "greater_than",
+                        "value": "0"
+                    }
                 ]
             }
         }
@@ -829,8 +889,11 @@
                             }
                         ]
                     },
-                    "greater_than_or_equal",
-                    "250"
+                    {
+                        "property": "result",
+                        "condition": "greater_than_or_equal",
+                        "value": "250"
+                    }
                 ]
             },
             "then": {
@@ -887,8 +950,11 @@
                             }
                         ]
                     },
-                    "greater_than",
-                    ".20"
+                    {
+                        "property": "result",
+                        "condition": "greater_than",
+                        "value": ".20"
+                    }
                 ]
             }
         }
@@ -928,8 +994,11 @@
                             }
                         ]
                     },
-                    "greater_than_or_equal",
-                    "250"
+                    {
+                        "property": "result",
+                        "condition": "greater_than_or_equal",
+                        "value": "250"
+                    }
                 ]
             },
             "then": {
@@ -986,8 +1055,11 @@
                             }
                         ]
                     },
-                    "greater_than",
-                    ".20"
+                    {
+                        "property": "result",
+                        "condition": "greater_than",
+                        "value": ".20"
+                    }
                 ]
             }
         }
@@ -1022,8 +1094,11 @@
                             }
                         ]
                     },
-                    "greater_than_or_equal",
-                    "750"
+                    {
+                        "property": "result",
+                        "condition": "greater_than_or_equal",
+                        "value": "750"
+                    }
                 ]
             },
             "then": {
@@ -1063,8 +1138,11 @@
                             }
                         ]
                     },
-                    "greater_than_or_equal",
-                    "750"
+                    {
+                        "property": "result",
+                        "condition": "greater_than_or_equal",
+                        "value": "750"
+                    }
                 ]
             },
             "then": {
@@ -1108,8 +1186,11 @@
                     "condition": "in",
                     "values": ["1", "2", "3", "4", "5"]
                 },
-                "less_than_or_equal",
-                ".50"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".50"
+                }
             ]
         }
     },
@@ -1147,8 +1228,11 @@
                     "condition": "in",
                     "values": ["1", "2", "3", "4", "5"]
                 },
-                "less_than_or_equal",
-                ".50"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".50"
+                }
             ]
         }
     },
@@ -1186,8 +1270,11 @@
                     "condition": "in",
                     "values": ["1", "2", "3", "4", "5"]
                 },
-                "less_than_or_equal",
-                ".50"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".50"
+                }
             ]
         }
     },
@@ -1235,8 +1322,11 @@
                     "condition": "in",
                     "values": ["1", "2", "3", "4", "5"]
                 },
-                "less_than_or_equal",
-                ".20"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".20"
+                }
             ]
         }
     },

--- a/2014/hmda-macro.json
+++ b/2014/hmda-macro.json
@@ -25,8 +25,11 @@
                         "condition": "equal",
                         "value": "2"
                     },
-                    "less_than",
-                    "2000"
+                    {
+                        "property": "result",
+                        "condition": "less_than",
+                        "value": "2000"
+                    }
                 ]
             },
             "then": {
@@ -40,8 +43,11 @@
                         "condition": "equal",
                         "value": "3"
                     },
-                    "less_than",
-                    "200"
+                    {
+                        "property": "result",
+                        "condition": "less_than",
+                        "value": "200"
+                    }
                 ]
             }
         }
@@ -71,8 +77,11 @@
                             }
                         ]
                     },
-                    "greater_than",
-                    "25"
+                    {
+                        "property": "result",
+                        "condition": "greater_than",
+                        "value": "25"
+                    }
                 ]
             },
             "then": {
@@ -100,8 +109,11 @@
                         "condition": "equal",
                         "value": "1"
                     },
-                    "less_than_or_equal",
-                    ".95"
+                    {
+                        "property": "result",
+                        "condition": "less_than_or_equal",
+                        "value": ".95"
+                    }
                 ]
             }
         }
@@ -135,8 +147,11 @@
                     "condition": "equal",
                     "value": "2"
                 },
-                "less_than_or_equal",
-                ".1"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".1"
+                }
             ]
         }
     },
@@ -169,8 +184,11 @@
                     "condition": "equal",
                     "value": "2"
                 },
-                "less_than_or_equal",
-                ".05"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".05"
+                }
             ]
         }
     },
@@ -194,8 +212,11 @@
                     "condition": "equal",
                     "value": "2"
                 },
-                "less_than_or_equal",
-                ".15"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".15"
+                }
             ]
         }
     },
@@ -219,8 +240,11 @@
                     "condition": "equal",
                     "value": "2"
                 },
-                "less_than_or_equal",
-                ".30"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".30"
+                }
             ]
         }
     },
@@ -244,8 +268,11 @@
                     "condition": "equal",
                     "value": "2"
                 },
-                "less_than_or_equal",
-                ".15"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".15"
+                }
             ]
         }
     },
@@ -269,8 +296,11 @@
                     "condition": "in",
                     "values": ["1", "2", "3", "4", "5", "6"]
                 },
-                "greater_than_or_equal",
-                ".20"
+                {
+                    "property": "result",
+                    "condition": "greater_than_or_equal",
+                    "value": ".20"
+                }
             ]
         }
     },
@@ -294,8 +324,11 @@
                     "condition": "equal",
                     "value": "2"
                 },
-                "less_than_or_equal",
-                ".30"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".30"
+                }
             ]
         }
     },
@@ -329,8 +362,11 @@
                     "condition": "equal",
                     "value": "2"
                 },
-                "less_than_or_equal",
-                ".20"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".20"
+                }
             ]
         }
     },
@@ -368,8 +404,11 @@
                     "condition": "equal",
                     "value": "1"
                 },
-                "less_than_or_equal",
-                ".01"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".01"
+                }
             ]
         }
     },
@@ -407,8 +446,11 @@
                     "condition": "equal",
                     "value": "6"
                 },
-                "less_than_or_equal",
-                ".01"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".01"
+                }
             ]
         }
     },
@@ -451,8 +493,11 @@
                     "condition": "equal",
                     "value": "1"
                 },
-                "less_than_or_equal",
-               ".01"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".01"
+                }
             ]
         }
     },
@@ -495,8 +540,11 @@
                     "condition": "equal",
                     "value": "1"
                 },
-                "less_than_or_equal",
-                ".01"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".01"
+                }
             ]
         }
     },
@@ -515,8 +563,11 @@
                     "condition": "equal",
                     "value": "1"
                 },
-                "less_than",
-                "200"
+                {
+                    "property": "result",
+                    "condition": "less_than",
+                    "value": "200"
+                }
             ]
         }
     },
@@ -563,8 +614,11 @@
                     "condition": "equal",
                     "value": "1"
                 },
-                "less_than_or_equal",
-                ".05"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".05"
+                }
             ]
         }
     },
@@ -616,8 +670,11 @@
                     "condition": "equal",
                     "value": "1"
                 },
-                "less_than_or_equal",
-                ".01"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".01"
+                }
             ]
         }
     },
@@ -646,8 +703,11 @@
                             }
                         ]
                     },
-                    "greater_than_or_equal",
-                    "50"
+                    {
+                        "property": "result",
+                        "condition": "greater_than_or_equal",
+                        "value": "50"
+                    }
                 ]
             },
             "then": {
@@ -689,8 +749,11 @@
                             }
                         ]
                     },
-                    "less_than_or_equal",
-                    ".70"
+                    {
+                        "property": "result",
+                        "condition": "less_than_or_equal",
+                        "value": ".70"
+                    }
                 ]
             }
         }
@@ -711,8 +774,11 @@
                         "condition": "equal",
                         "value": "2"
                     },
-                    "greater_than_or_equal",
-                    "50"
+                    {
+                        "property": "result",
+                        "condition": "greater_than_or_equal",
+                        "value": "50"
+                    }
                 ]
             },
             "then": {
@@ -726,8 +792,11 @@
                         "condition": "equal",
                         "value": "3"
                     },
-                    "greater_than",
-                    "0"
+                    {
+                        "property": "result",
+                        "condition": "greater_than",
+                        "value": "0"
+                    }
                 ]
             }
         }
@@ -748,8 +817,11 @@
                         "condition": "equal",
                         "value": "1"
                     },
-                    "greater_than_or_equal",
-                    "1000"
+                    {
+                        "property": "result",
+                        "condition": "greater_than_or_equal",
+                        "value": "1000"
+                    }
                 ]
             },
             "then": {
@@ -763,8 +835,11 @@
                         "condition": "equal",
                         "value": "7"
                     },
-                    "greater_than",
-                    "0"
+                    {
+                        "property": "result",
+                        "condition": "greater_than",
+                        "value": "0"
+                    }
                 ]
             }
         }
@@ -834,8 +909,11 @@
                             }
                         ]
                     },
-                    "greater_than_or_equal",
-                    "250"
+                    {
+                        "property": "result",
+                        "condition": "greater_than_or_equal",
+                        "value": "250"
+                    }
                 ]
             },
             "then": {
@@ -892,8 +970,11 @@
                             }
                         ]
                     },
-                    "greater_than",
-                    ".20"
+                    {
+                        "property": "result",
+                        "condition": "greater_than",
+                        "value": ".20"
+                    }
                 ]
             }
         }
@@ -933,8 +1014,11 @@
                             }
                         ]
                     },
-                    "greater_than_or_equal",
-                    "250"
+                    {
+                        "property": "result",
+                        "condition": "greater_than_or_equal",
+                        "value": "250"
+                    }
                 ]
             },
             "then": {
@@ -991,8 +1075,11 @@
                             }
                         ]
                     },
-                    "greater_than",
-                    ".20"
+                    {
+                        "property": "result",
+                        "condition": "greater_than",
+                        "value": ".20"
+                    }
                 ]
             }
         }
@@ -1027,8 +1114,11 @@
                             }
                         ]
                     },
-                    "greater_than_or_equal",
-                    "750"
+                    {
+                        "property": "result",
+                        "condition": "greater_than_or_equal",
+                        "value": "750"
+                    }
                 ]
             },
             "then": {
@@ -1068,8 +1158,11 @@
                             }
                         ]
                     },
-                    "greater_than_or_equal",
-                    "750"
+                    {
+                        "property": "result",
+                        "condition": "greater_than_or_equal",
+                        "value": "750"
+                    }
                 ]
             },
             "then": {
@@ -1113,8 +1206,11 @@
                     "condition": "in",
                     "values": ["1", "2", "3", "4", "5"]
                 },
-                "less_than_or_equal",
-                ".50"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".50"
+                }
             ]
         }
     },
@@ -1152,8 +1248,11 @@
                     "condition": "in",
                     "values": ["1", "2", "3", "4", "5"]
                 },
-                "less_than_or_equal",
-                ".50"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".50"
+                }
             ]
         }
     },
@@ -1191,8 +1290,11 @@
                     "condition": "in",
                     "values": ["1", "2", "3", "4", "5"]
                 },
-                "less_than_or_equal",
-                ".50"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".50"
+                }
             ]
         }
     },
@@ -1240,8 +1342,11 @@
                     "condition": "in",
                     "values": ["1", "2", "3", "4", "5"]
                 },
-                "less_than_or_equal",
-                ".20"
+                {
+                    "property": "result",
+                    "condition": "less_than_or_equal",
+                    "value": ".20"
+                }
             ]
         }
     },


### PR DESCRIPTION
Conditions for compareNumEntriesSingle and compareNumEntries are now sub-rules rather than two individual strings. These previously relied on falling through on lookup to be passed in as raw strings but the lookup code now throws an exception in this case. 