### PR TITLE
We should return null when things aren't found, not empty sets

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ var SpecAPI = function() {
         try {
             return require('./' + year + '/data_file_specification.json');
         } catch (e) {
-            return {};
+            return null;
         }
     };
 
@@ -31,7 +31,7 @@ var SpecAPI = function() {
         try {
             return require('./' + year + '/' + objectType + '-' + editType + '.json');
         } catch (e) {
-            return [];
+            return null;
         }
     };
 

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -34,7 +34,7 @@ describe('getFileSpec', function() {
 
     it('should return an empty object for an invalid year', function(done) {
         var spec = specAPI.getFileSpec('2000');
-        expect(spec).to.be.empty();
+        expect(spec).to.be.null();
         done();
     });
 });
@@ -48,7 +48,7 @@ describe('getEdits', function() {
 
     it('should return an empty list for an invalid year, editType, objectType combo', function(done) {
         var edits = specAPI.getEdits('2013', 'hmda', 'validity');
-        expect(edits).to.be.empty();
+        expect(edits).to.be.null();
         done();
     });
 });


### PR DESCRIPTION
It's more appropriate to return null, not empty sets, so that calling functions to these API functions can do proper error handling, instead of assuming everything went correctly like an empty set would assume.