### PR TITLE
Require all the things

### DIFF
--- a/2014/lar-validity.json
+++ b/2014/lar-validity.json
@@ -1077,7 +1077,7 @@
                     {
                         "property": "coapplicantRace1",
                         "condition": "equal",
-                        "value": "8",
+                        "value": "8"
                     },
                     {
                         "property": "coapplicantSex",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,7 +75,11 @@ module.exports = function (grunt) {
                 jshintrc: '.jshintrc'
             }
         },
-
+        jsonlint: {
+            specs: {
+                src: [ '2013/*.json', '2014/*.json' ]
+            }
+        }
     });
 
 
@@ -86,10 +90,11 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-env');
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-release');
+    grunt.loadNpmTasks('grunt-jsonlint');
 
     // Register group tasks
     grunt.registerTask('clean_all', [ 'clean:node_modules', 'clean:coverage', 'npm_install' ]);
-    grunt.registerTask('test', ['env:test', 'clean:coverage', 'jshint', 'mocha_istanbul']);
+    grunt.registerTask('test', ['env:test', 'clean:coverage', 'jshint', 'jsonlint:specs', 'mocha_istanbul']);
     grunt.registerTask('coverage', ['env:test', 'clean:coverage', 'jshint', 'mocha_istanbul', 'open_coverage' ]);
 
 };

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var spec2013 = require('./2013/data_file_specification.json'),
 
 var // 2013 Edits
     hmdaMacro2013 = require('./2013/hmda-macro.json'),
-    hmdasyntactical2013 = require('./2013/hmda-syntactical.json'),
+    hmdaSyntactical2013 = require('./2013/hmda-syntactical.json'),
     larQuality2013 = require('./2013/lar-quality.json'),
     larSyntactical2013 = require('./2013/lar-syntactical.json'),
     larValidity2013 = require('./2013/lar-validity.json'),
@@ -22,7 +22,7 @@ var // 2013 Edits
     tsValidity2013 = require('./2013/ts-validity.json'),
     // // 2014 Edits
     hmdaMacro2014 = require('./2014/hmda-macro.json'),
-    hmdasyntactical2014 = require('./2014/hmda-syntactical.json'),
+    hmdaSyntactical2014 = require('./2014/hmda-syntactical.json'),
     larQuality2014 = require('./2014/lar-quality.json'),
     larSyntactical2014 = require('./2014/lar-syntactical.json'),
     larValidity2014 = require('./2014/lar-validity.json'),
@@ -34,7 +34,7 @@ var // 2013 Edits
         '2013': {
             'hmda': {
                 'macro': hmdaMacro2013,
-                'syntactical': hmdasyntactical2013
+                'syntactical': hmdaSyntactical2013
             },
             'lar': {
                 'quality': larQuality2013,
@@ -50,7 +50,7 @@ var // 2013 Edits
         '2014': {
             'hmda': {
                 'macro': hmdaMacro2014,
-                'syntactical': hmdasyntactical2014
+                'syntactical': hmdaSyntactical2014
             },
             'lar': {
                 'quality': larQuality2014,

--- a/index.js
+++ b/index.js
@@ -4,6 +4,67 @@ var VALID_YEARS = ['2013', '2014'];
 var VALID_OBJECT_TYPES = ['hmda', 'ts', 'lar'];
 var VALID_EDIT_TYPES = ['validity', 'syntactical', 'quality', 'macro'];
 
+var spec2013 = require('./2013/data_file_specification.json'),
+    spec2014 = require('./2014/data_file_specification.json'),
+    specs = {
+        '2013': spec2013,
+        '2014': spec2014
+    };
+
+var // 2013 Edits
+    hmdaMacro2013 = require('./2013/hmda-macro.json'),
+    hmdasyntactical2013 = require('./2013/hmda-syntactical.json'),
+    larQuality2013 = require('./2013/lar-quality.json'),
+    larSyntactical2013 = require('./2013/lar-syntactical.json'),
+    larValidity2013 = require('./2013/lar-validity.json'),
+    tsQuality2013 = require('./2013/ts-quality.json'),
+    tsSyntactical2013 = require('./2013/ts-syntactical.json'),
+    tsValidity2013 = require('./2013/ts-validity.json'),
+    // // 2014 Edits
+    hmdaMacro2014 = require('./2014/hmda-macro.json'),
+    hmdasyntactical2014 = require('./2014/hmda-syntactical.json'),
+    larQuality2014 = require('./2014/lar-quality.json'),
+    larSyntactical2014 = require('./2014/lar-syntactical.json'),
+    larValidity2014 = require('./2014/lar-validity.json'),
+    tsQuality2014 = require('./2014/ts-quality.json'),
+    tsSyntactical2014 = require('./2014/ts-syntactical.json'),
+    tsValidity2014 = require('./2014/ts-validity.json'),
+    // Edits object
+    edits = {
+        '2013': {
+            'hmda': {
+                'macro': hmdaMacro2013,
+                'syntactical': hmdasyntactical2013
+            },
+            'lar': {
+                'quality': larQuality2013,
+                'syntactical': larSyntactical2013,
+                'validity': larValidity2013
+            },
+            'ts': {
+                'quality': tsQuality2013,
+                'syntactical': tsSyntactical2013,
+                'validity': tsValidity2013
+            }
+        },
+        '2014': {
+            'hmda': {
+                'macro': hmdaMacro2014,
+                'syntactical': hmdasyntactical2014
+            },
+            'lar': {
+                'quality': larQuality2014,
+                'syntactical': larSyntactical2014,
+                'validity': larValidity2014
+            },
+            'ts': {
+                'quality': tsQuality2014,
+                'syntactical': tsSyntactical2014,
+                'validity': tsValidity2014
+            }
+        }
+    };
+
 var SpecAPI = function() {
     var api = {};
 
@@ -20,17 +81,17 @@ var SpecAPI = function() {
     };
 
     api.getFileSpec = function(year) {
-        try {
-            return require('./' + year + '/data_file_specification.json');
-        } catch (e) {
+        if (specs[year]) {
+            return specs[year];
+        } else {
             return null;
         }
     };
 
     api.getEdits = function(year, objectType, editType) {
-        try {
-            return require('./' + year + '/' + objectType + '-' + editType + '.json');
-        } catch (e) {
+        if (edits[year][objectType][editType]) {
+            return edits[year][objectType][editType];
+        } else {
             return null;
         }
     };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-develop": "^0.4.0",
     "grunt-env": "~0.4.1",
+    "grunt-jsonlint": "^1.0.4",
     "grunt-mocha-istanbul": "^1.4.1",
     "grunt-mocha-test": "^0.10.2",
     "grunt-release": "^0.7.0",

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -1,3 +1,9 @@
+/*global describe:false*/
+/*global it:false*/
+/*global expect:false*/
+/*global beforeEach:false*/
+/*global rewire:false*/
+/*global _:false*/
 'use strict';
 
 describe('getValidYears', function() {


### PR DESCRIPTION
Require all of the JSON spec files rather than dynamically loading them as intended.

Due to substack/node-browserify#377, we have to require all of the JSON spec files and then provide an interface for only returning the ones we want from getFileSpec and getEdits.