### PR TITLE
Updates to make sure we're referencing hmdaFile where necessary

### DIFF
--- a/2013/hmda-macro.json
+++ b/2013/hmda-macro.json
@@ -18,7 +18,7 @@
             "condition": "call",
             "function": "compareNumEntriesSingle",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "property": "propertyType",
                     "condition": "equal",
@@ -42,7 +42,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -69,7 +69,7 @@
                 "condition": "call",
                 "function": "compareNumEntries",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -107,7 +107,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -144,7 +144,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -181,7 +181,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "property": "actionTaken",
                     "condition": "equal",
@@ -209,7 +209,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "property": "actionTaken",
                     "condition": "equal",
@@ -237,7 +237,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "property": "actionTaken",
                     "condition": "equal",
@@ -265,7 +265,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "property": "actionTaken",
                     "condition": "equal",
@@ -293,7 +293,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "property": "metroArea",
                     "condition": "equal",
@@ -331,7 +331,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "property": "applicantIncome",
                     "condition": "less_than",
@@ -359,7 +359,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -401,7 +401,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -443,7 +443,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -490,7 +490,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -537,7 +537,7 @@
             "condition": "call",
             "function": "compareNumEntriesSingle",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "property": "hoepaStatus",
                     "condition": "equal",
@@ -560,7 +560,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -611,7 +611,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -668,7 +668,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -695,7 +695,7 @@
                 "condition": "call",
                 "function": "compareNumEntries",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -748,7 +748,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "property": "recordID",
                         "condition": "equal",
@@ -766,7 +766,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "property": "actionTaken",
                         "condition": "equal",
@@ -791,7 +791,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "property": "preapprovals",
                         "condition": "equal",
@@ -809,7 +809,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "property": "actionTaken",
                         "condition": "equal",
@@ -864,7 +864,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -901,7 +901,7 @@
                 "condition": "call",
                 "function": "compareNumEntries",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -969,7 +969,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -1006,7 +1006,7 @@
                 "condition": "call",
                 "function": "compareNumEntries",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -1074,7 +1074,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -1118,7 +1118,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -1161,7 +1161,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -1203,7 +1203,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -1245,7 +1245,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -1287,7 +1287,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {

--- a/2013/lar-syntactical.json
+++ b/2013/lar-syntactical.json
@@ -17,7 +17,7 @@
             "property": "actionDate",
             "condition": "call",
             "function": "isActionDateInActivityYear",
-            "args": ["actionDate", "transmittalSheet.activityYear"]
+            "args": ["actionDate", "hmdaFile.transmittalSheet.activityYear"]
         }
     }
 ]

--- a/2014/hmda-macro.json
+++ b/2014/hmda-macro.json
@@ -19,7 +19,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "property": "recordID",
                         "condition": "equal",
@@ -37,7 +37,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "property": "propertyType",
                         "condition": "equal",
@@ -62,7 +62,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -89,7 +89,7 @@
                 "condition": "call",
                 "function": "compareNumEntries",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -127,7 +127,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -164,7 +164,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -201,7 +201,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "property": "actionTaken",
                     "condition": "equal",
@@ -229,7 +229,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "property": "actionTaken",
                     "condition": "equal",
@@ -257,7 +257,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "property": "actionTaken",
                     "condition": "equal",
@@ -285,7 +285,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "property": "actionTaken",
                     "condition": "equal",
@@ -313,7 +313,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "property": "metroArea",
                     "condition": "equal",
@@ -351,7 +351,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "property": "applicantIncome",
                     "condition": "less_than",
@@ -379,7 +379,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -421,7 +421,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -463,7 +463,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -510,7 +510,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -557,7 +557,7 @@
             "condition": "call",
             "function": "compareNumEntriesSingle",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "property": "hoepaStatus",
                     "condition": "equal",
@@ -580,7 +580,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -631,7 +631,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -688,7 +688,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -715,7 +715,7 @@
                 "condition": "call",
                 "function": "compareNumEntries",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -768,7 +768,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "property": "recordID",
                         "condition": "equal",
@@ -786,7 +786,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "property": "actionTaken",
                         "condition": "equal",
@@ -811,7 +811,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "property": "preapprovals",
                         "condition": "equal",
@@ -829,7 +829,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "property": "actionTaken",
                         "condition": "equal",
@@ -884,7 +884,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -921,7 +921,7 @@
                 "condition": "call",
                 "function": "compareNumEntries",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -989,7 +989,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -1026,7 +1026,7 @@
                 "condition": "call",
                 "function": "compareNumEntries",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -1094,7 +1094,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -1138,7 +1138,7 @@
                 "condition": "call",
                 "function": "compareNumEntriesSingle",
                 "args": [
-                    "loanApplicationRegisters",
+                    "hmdaFile.loanApplicationRegisters",
                     {
                         "and": [
                             {
@@ -1181,7 +1181,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -1223,7 +1223,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -1265,7 +1265,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {
@@ -1307,7 +1307,7 @@
             "condition": "call",
             "function": "compareNumEntries",
             "args": [
-                "loanApplicationRegisters",
+                "hmdaFile.loanApplicationRegisters",
                 {
                     "and": [
                         {

--- a/2014/lar-syntactical.json
+++ b/2014/lar-syntactical.json
@@ -17,7 +17,7 @@
             "property": "actionDate",
             "condition": "call",
             "function": "isActionDateInActivityYear",
-            "args": ["actionDate", "transmittalSheet.activityYear"]
+            "args": ["actionDate", "hmdaFile.transmittalSheet.activityYear"]
         }
     }
 ]


### PR DESCRIPTION
An issue where the HMDA JSON structure was being generated with double nested hmdaFile properties causes an issue here with the edit definitions when you remove it. Make sure we're using an explicit path starting from root of the HMDA JSON