### PR TITLE
Add formats and values to spec

### DIFF
--- a/2013/data_file_specification.json
+++ b/2013/data_file_specification.json
@@ -10,6 +10,7 @@
                "end": "1",
                "length": "1",
                "dataType": "N",
+               "format": "number",
                "description": "Value is 1"
           },
           "respondentID": {
@@ -18,6 +19,7 @@
                "end": "11",
                "length": "10",
                "dataType": "AN",
+               "format": "string",
                "description": "Assigned by your federal regulatory agency. Format is right-justified and zero filled."
           },
           "agencyCode": {
@@ -26,7 +28,16 @@
                "end": "12",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1=OCC, 2=FRS, 3=FDIC, 5=NCUA, 7=HUD, or 9=CFPB"
+               "format": "number",
+               "description": "Values are 1=OCC, 2=FRS, 3=FDIC, 5=NCUA, 7=HUD, or 9=CFPB",
+               "values": {
+                   "1": "OCC",
+                   "2": "FRS",
+                   "3": "FDIC",
+                   "5": "NCUA",
+                   "7": "HUD",
+                   "9": "CFPB"
+               }
           },
           "timestamp": {
                "label": "Timestamp",
@@ -34,6 +45,7 @@
                "end": "24",
                "length": "12",
                "dataType": "N",
+               "format": "datetime",
                "description": "Format is century, year, month, day, hour, minute (e.g., Jan. 17, 2013, at 1:30 pm would be 201301171330)"
           },
           "filler": {
@@ -50,6 +62,7 @@
                "end": "29",
                "length": "4",
                "dataType": "N",
+               "format": "year",
                "description": "Four digit year (e.g., 2013)"
           },
           "taxID": {
@@ -58,6 +71,7 @@
                "end": "39",
                "length": "10",
                "dataType": "AN",
+               "format": "string",
                "description": "Format is 99-9999999"
           },
           "totalLineEntries": {
@@ -66,6 +80,7 @@
                "end": "46",
                "length": "7",
                "dataType": "N",
+               "format": "number",
                "description": "The N of line entries contained in the accompanying Loan/Application Register"
           },
           "institutionName": {
@@ -74,6 +89,7 @@
                "end": "76",
                "length": "30",
                "dataType": "AN",
+               "format": "string",
                "description": "Left-justified and upper case"
           },
           "respondentAddress": {
@@ -82,6 +98,7 @@
                "end": "116",
                "length": "40",
                "dataType": "AN",
+               "format": "string",
                "description": "Left-justified"
           },
           "respondentCity": {
@@ -90,6 +107,7 @@
                "end": "141",
                "length": "25",
                "dataType": "AN",
+               "format": "string",
                "description": "Left-justified"
           },
           "respondentState": {
@@ -98,6 +116,7 @@
                "end": "143",
                "length": "2",
                "dataType": "AN",
+               "format": "string",
                "description": "Postal Code abbreviation"
           },
           "respondentZip": {
@@ -106,6 +125,7 @@
                "end": "153",
                "length": "10",
                "dataType": "AN",
+               "format": "string",
                "description": "Format is 99999 left-justified or Code 99999-9999"
           },
           "parentName": {
@@ -114,6 +134,7 @@
                "end": "183",
                "length": "30",
                "dataType": "AN",
+               "format": "string",
                "description": "If applicable"
           },
           "parentAddress": {
@@ -122,6 +143,7 @@
                "end": "223",
                "length": "40",
                "dataType": "AN",
+               "format": "string",
                "description": "If applicable"
           },
           "parentCity": {
@@ -130,6 +152,7 @@
                "end": "248",
                "length": "25",
                "dataType": "AN",
+               "format": "string",
                "description": "If applicable"
           },
           "parentState": {
@@ -138,6 +161,7 @@
                "end": "250",
                "length": "2",
                "dataType": "AN",
+               "format": "string",
                "description": "If applicable"
           },
           "parentZip": {
@@ -146,6 +170,7 @@
                "end": "260",
                "length": "10",
                "dataType": "AN",
+               "format": "string",
                "description": "If applicable; format is 99999 left-justified or 99999-9999"
           },
           "contactName": {
@@ -154,6 +179,7 @@
                "end": "290",
                "length": "30",
                "dataType": "AN",
+               "format": "string",
                "description": "For questionable data, reports, or other issues that may arise during an annual processing cycle."
           },
           "contactPhone": {
@@ -162,6 +188,7 @@
                "end": "302",
                "length": "12",
                "dataType": "AN",
+               "format": "phoneNumber",
                "description": "Format is 999-999-9999"
           },
           "contactFax": {
@@ -170,6 +197,7 @@
                "end": "314",
                "length": "12",
                "dataType": "AN",
+               "format": "phoneNumber",
                "description": "Format is 999-999-9999"
           },
           "respondentEmail": {
@@ -178,6 +206,7 @@
                "end": "380",
                "length": "66",
                "dataType": "AN",
+               "format": "emailAddress",
                "description": "Enter only one e-mail address. E-mail address must contain only one @ symbol. Format is left-justified."
           }
      },
@@ -188,6 +217,7 @@
                "end": "1",
                "length": "1",
                "dataType": "N",
+               "format": "number",
                "description": "Value is 2"
           },
           "respondentID": {
@@ -196,6 +226,7 @@
                "end": "11",
                "length": "10",
                "dataType": "AN",
+               "format": "string",
                "description": "Assigned by your federal regulatory agency. Format is right-justified and zero-filled."
           },
           "agencyCode": {
@@ -204,7 +235,16 @@
                "end": "12",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1=OCC, 2=FRS, 3=FDIC, 5=NCUA, 7=HUD, or 9=CFPB"
+               "format": "number",
+               "description": "Values are 1=OCC, 2=FRS, 3=FDIC, 5=NCUA, 7=HUD, or 9=CFPB",
+               "values": {
+                   "1": "OCC",
+                   "2": "FRS",
+                   "3": "FDIC",
+                   "5": "NCUA",
+                   "7": "HUD",
+                   "9": "CFPB"
+               }
           },
           "loanNumber": {
                "label": "Loan/Application Number",
@@ -212,6 +252,7 @@
                "end": "37",
                "length": "25",
                "dataType": "AN",
+               "format": "string",
                "description": "Unique identifier across the home office and branch sites"
           },
           "applicationReceivedDate": {
@@ -220,6 +261,7 @@
                "end": "45",
                "length": "8",
                "dataType": "AN",
+               "format": "date",
                "description": "Format is ccyymmdd or NA left-justified"
           },
           "loanType": {
@@ -228,7 +270,14 @@
                "end": "46",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, 3, or 4"
+               "format": "number",
+               "description": "Values are 1, 2, 3, or 4",
+               "values": {
+                    "1": "Conventional (any loan other than FHA, VA, FSA, or RHS loans)",
+                    "2": "FHA-insured (Federal Housing Administration)",
+                    "3": "VA-guaranteed (Veterans Administration)",
+                    "4": "FSA/RHS (Farm Service Agency or Rural Housing Service)"
+               }
           },
           "propertyType": {
                "label": "Property Type",
@@ -236,7 +285,13 @@
                "end": "47",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, or 3"
+               "format": "number",
+               "description": "Values are 1, 2, or 3",
+               "values": {
+                    "1": "One to four-family (other than manufactured housing)",
+                    "2": "Manufactured housing",
+                    "3": "Multifamily"
+               }
           },
           "loanPurpose": {
                "label": "Loan Purpose",
@@ -244,7 +299,13 @@
                "end": "48",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, or 3"
+               "format": "number",
+               "description": "Values are 1, 2, or 3",
+               "values": {
+                   "1": "Home purchase",
+                   "2": "Home improvement",
+                   "3": "Refinancing"
+               }
           },
           "ownerOccupancy": {
                "label": "Owner Occupancy",
@@ -252,7 +313,13 @@
                "end": "49",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, or 3"
+               "format": "number",
+               "description": "Values are 1, 2, or 3",
+               "values": {
+                   "1": "Owner-occupied as a principal dwelling",
+                   "2": "Not owner-occupied",
+                   "3": "Not applicable"
+               }
           },
           "loanAmount": {
                "label": "Loan Amount",
@@ -260,6 +327,7 @@
                "end": "54",
                "length": "5",
                "dataType": "N",
+               "format": "currency",
                "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas"
           },
           "preapprovals": {
@@ -268,7 +336,13 @@
                "end": "55",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, or 3"
+               "format": "number",
+               "description": "Values are 1, 2, or 3",
+               "values": {
+                    "1": "Preapproval was requested",
+                    "2": "Preapproval was not requested",
+                    "3": "Not applicable"
+               }
           },
           "actionTaken": {
                "label": "Type of Action Taken",
@@ -276,7 +350,18 @@
                "end": "56",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, 3, 4, 5, 6, 7, OR 8"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, 6, 7, OR 8",
+               "values": {
+                    "1": "Loan originated",
+                    "2": "Application approved but not accepted",
+                    "3": "Application denied by financial institution",
+                    "4": "Application withdrawn by applicant",
+                    "5": "File closed for incompleteness",
+                    "6": "Loan purchased by the institution",
+                    "7": "Preapproval request denied by financial institution",
+                    "8": "Preapproval request approved but not accepted (optional reporting)"
+               }
           },
           "actionDate": {
                "label": "Date of Action",
@@ -284,6 +369,7 @@
                "end": "64",
                "length": "8",
                "dataType": "N",
+               "format": "date",
                "description": "Format is ccyymmdd"
           },
           "metroArea": {
@@ -292,6 +378,7 @@
                "end": "69",
                "length": "5",
                "dataType": "AN",
+               "format": "string",
                "description": "Metropolitan Statistical Area or Metropolitan Division (if appropriate) code or NA left-justified"
           },
           "fipsState": {
@@ -300,6 +387,7 @@
                "end": "71",
                "length": "2",
                "dataType": "AN",
+               "format": "string",
                "description": "FIPS code with leading zerosor NA left-justified"
           },
           "fipsCounty": {
@@ -308,6 +396,7 @@
                "end": "74",
                "length": "3",
                "dataType": "AN",
+               "format": "string",
                "description": "FIPS code with leading zeros or NA left-justified"
           },
           "censusTract": {
@@ -316,6 +405,7 @@
                "end": "81",
                "length": "7",
                "dataType": "AN",
+               "format": "string",
                "description": "Include decimal point and any leading or trailing zeros or NA left-justified"
           },
           "applicantEthnicity": {
@@ -324,7 +414,14 @@
                "end": "82",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, 3, or 4"
+               "format": "number",
+               "description": "Values are 1, 2, 3, or 4",
+               "values": {
+                    "1": "Hispanic or Latino",
+                    "2": "Not Hispanic or Latino",
+                    "3": "Information not provided by applicant in mail, Internet, or telephone application",
+                    "4": "Not applicable"
+               }
           },
           "coapplicantEthnicity": {
                "label": "Co-applicant Ethnicity",
@@ -332,7 +429,15 @@
                "end": "83",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, 3, 4, or 5"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, or 5",
+               "values": {
+                    "1": "Hispanic or Latino",
+                    "2": "Not Hispanic or Latino",
+                    "3": "Information not provided by applicant in mail, Internet, or telephone application",
+                    "4": "Not applicable",
+                    "5": "No co-applicant"
+               }
           },
           "applicantRace1": {
                "label": "Applicant Race: 1",
@@ -340,7 +445,17 @@
                "end": "84",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, 3, 4, 5, 6, or 7"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, 6, or 7",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White",
+                   "6": "Information not provided by applicant in mail, Internet, or telephone application",
+                   "7": "Not applicable"
+               }
           },
           "applicantRace2": {
                "label": "Applicant Race: 2",
@@ -348,7 +463,15 @@
                "end": "85",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, or blank",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White"
+               }
           },
           "applicantRace3": {
                "label": "Applicant Race: 3",
@@ -356,7 +479,15 @@
                "end": "86",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, or blank",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White"
+               }
           },
           "applicantRace4": {
                "label": "Applicant Race: 4",
@@ -364,7 +495,15 @@
                "end": "87",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, or blank",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White"
+               }
           },
           "applicantRace5": {
                "label": "Applicant Race: 5",
@@ -372,7 +511,15 @@
                "end": "88",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, or blank",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White"
+               }
           },
           "coapplicantRace1": {
                "label": "Co-applicant Race: 1",
@@ -380,7 +527,18 @@
                "end": "89",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, 3, 4, 5, 6, 7, or 8"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, 6, 7, or 8",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White",
+                   "6": "Information not provided by applicant in mail, Internet, or telephone application",
+                   "7": "Not applicable",
+                   "8": "No co-applicant"
+               }
           },
           "coapplicantRace2": {
                "label": "Co-applicant Race: 2",
@@ -388,7 +546,15 @@
                "end": "90",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, or blank",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White"
+               }
           },
           "coapplicantRace3": {
                "label": "Co-applicant Race: 3",
@@ -396,7 +562,15 @@
                "end": "91",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, or blank",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White"
+               }
           },
           "coapplicantRace4": {
                "label": "Co-applicant Race: 4",
@@ -404,7 +578,15 @@
                "end": "92",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, or blank",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White"
+               }
           },
           "coapplicantRace5": {
                "label": "Co-applicant Race: 5",
@@ -412,7 +594,15 @@
                "end": "93",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, or blank",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White"
+               }
           },
           "applicantSex": {
                "label": "Applicant Sex",
@@ -420,7 +610,14 @@
                "end": "94",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, 3, or 4"
+               "format": "number",
+               "description": "Values are 1, 2, 3, or 4",
+               "values": {
+                   "1": "Male",
+                   "2": "Female",
+                   "3": "Information not provided by applicant in mail, Internet, or telephone application",
+                   "4": "Not applicable"
+               }
           },
           "coapplicantSex": {
                "label": "Co-applicant Sex",
@@ -428,7 +625,15 @@
                "end": "95",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, 3, 4, or 5"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, or 5",
+               "values": {
+                   "1": "Male",
+                   "2": "Female",
+                   "3": "Information not provided by applicant in mail, Internet, or telephone application",
+                   "4": "Not applicable",
+                   "5": "No co-applicant"
+               }
           },
           "applicantIncome": {
                "label": "Applicant Income",
@@ -436,6 +641,7 @@
                "end": "99",
                "length": "4",
                "dataType": "AN",
+               "format": "currency",
                "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas or NA left-justified"
           },
           "purchaserType": {
@@ -444,7 +650,20 @@
                "end": "100",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 0, 1, 2, 3, 4, 5, 6, 7, 8, or 9"
+               "format": "number",
+               "description": "Values are 0, 1, 2, 3, 4, 5, 6, 7, 8, or 9",
+               "values": {
+                    "0": "Loan was not originated or was not sold in calendar year covered by register",
+                    "1": "Fannie Mae (FNMA)",
+                    "2": "Ginnie Mae (GNMA)",
+                    "3": "Freddie Mac (FHLMC)",
+                    "4": "Farmer Mac (FAMC)",
+                    "5": "Private securitization",
+                    "6": "Commercial bank, savings bank or savings association",
+                    "7": "Life insurance company, credit union, mortgage bank, or finance company",
+                    "8": "Affiliate institution",
+                    "9": "Other type of purchaser"
+               }
           },
           "denialReason1": {
                "label": "Denial Reason: 1",
@@ -452,7 +671,19 @@
                "end": "101",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank",
+               "values": {
+                   "1": "Debt-to-income ratio",
+                   "2": "Employment history",
+                   "3": "Credit history",
+                   "4": "Collateral",
+                   "5": "Insufficient cash (downpayment, closing costs)",
+                   "6": "Unverifiable information",
+                   "7": "Credit application incomplete",
+                   "8": "Mortgage insurance denied",
+                   "9": "Other"
+               }
           },
           "denialReason2": {
                "label": "Denial Reason: 2",
@@ -460,7 +691,19 @@
                "end": "102",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank",
+               "values": {
+                   "1": "Debt-to-income ratio",
+                   "2": "Employment history",
+                   "3": "Credit history",
+                   "4": "Collateral",
+                   "5": "Insufficient cash (downpayment, closing costs)",
+                   "6": "Unverifiable information",
+                   "7": "Credit application incomplete",
+                   "8": "Mortgage insurance denied",
+                   "9": "Other"
+               }
           },
           "denialReason3": {
                "label": "Denial Reason: 3",
@@ -468,7 +711,19 @@
                "end": "103",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank",
+               "values": {
+                   "1": "Debt-to-income ratio",
+                   "2": "Employment history",
+                   "3": "Credit history",
+                   "4": "Collateral",
+                   "5": "Insufficient cash (downpayment, closing costs)",
+                   "6": "Unverifiable information",
+                   "7": "Credit application incomplete",
+                   "8": "Mortgage insurance denied",
+                   "9": "Other"
+               }
           },
           "rateSpread": {
                "label": "Rate Spread",
@@ -476,6 +731,7 @@
                "end": "108",
                "length": "5",
                "dataType": "AN",
+               "format": "percent",
                "description": "Enter the rate spread to two decimal places. Include the decimal point and any leading or trailing zeros or NA left-justified"
           },
           "hoepaStatus": {
@@ -484,7 +740,12 @@
                "end": "109",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1 or 2"
+               "format": "number",
+               "description": "Values are 1 or 2",
+               "values": {
+                    "1": "HOEPA loan",
+                    "2": "Not a HOEPA loan"
+               }
           },
           "lienStatus": {
                "label": "Lien Status",
@@ -492,7 +753,14 @@
                "end": "110",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, 3, or 4"
+               "format": "number",
+               "description": "Values are 1, 2, 3, or 4",
+               "values": {
+                    "1": "Secured by a first lien",
+                    "2": "Secured by a subordinate lien",
+                    "3": "Not secured by a lien",
+                    "4": "Not applicable (purchased loans)"
+               }
           },
           "filler": {
                "label": "Filler",

--- a/2013/data_file_specification.json
+++ b/2013/data_file_specification.json
@@ -60,7 +60,7 @@
                "dataType": "N",
                "description": "Format is century, year, month, day, hour, minute (e.g., Jan. 17, 2013, at 1:30 pm would be 201301171330)",
                "validation": {
-                   "type": "datetime",
+                   "type": "date",
                    "match": "yyyyMMddHHmm",
                    "canBeBlank": false,
                    "canBeNA": false
@@ -86,7 +86,8 @@
                "dataType": "N",
                "description": "Four digit year (e.g., 2013)",
                "validation": {
-                   "type": "year",
+                   "type": "date",
+                   "match": "yyyy",
                    "canBeBlank": false,
                    "canBeNA": false
                }

--- a/2013/data_file_specification.json
+++ b/2013/data_file_specification.json
@@ -461,9 +461,9 @@
                "length": "2",
                "dataType": "AN",
                "format": "string",
-               "description": "FIPS code with leading zerosor NA left-justified"
                "canBeBlank": false,
                "canBeNA": true,
+               "description": "FIPS code with leading zeros or NA left-justified"
           },
           "fipsCounty": {
                "label": "County Code",

--- a/2013/data_file_specification.json
+++ b/2013/data_file_specification.json
@@ -12,6 +12,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Value is 1"
           },
           "respondentID": {
@@ -21,6 +23,8 @@
                "length": "10",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Assigned by your federal regulatory agency. Format is right-justified and zero filled."
           },
           "agencyCode": {
@@ -30,6 +34,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1=OCC, 2=FRS, 3=FDIC, 5=NCUA, 7=HUD, or 9=CFPB",
                "values": {
                    "1": "OCC",
@@ -47,6 +53,8 @@
                "length": "12",
                "dataType": "N",
                "format": "datetime",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Format is century, year, month, day, hour, minute (e.g., Jan. 17, 2013, at 1:30 pm would be 201301171330)"
           },
           "filler": {
@@ -55,6 +63,8 @@
                "end": "25",
                "length": "1",
                "dataType": "AN",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Blank"
           },
           "activityYear": {
@@ -64,6 +74,8 @@
                "length": "4",
                "dataType": "N",
                "format": "year",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Four digit year (e.g., 2013)"
           },
           "taxID": {
@@ -73,6 +85,8 @@
                "length": "10",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Format is 99-9999999"
           },
           "totalLineEntries": {
@@ -82,6 +96,8 @@
                "length": "7",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "The N of line entries contained in the accompanying Loan/Application Register"
           },
           "institutionName": {
@@ -91,6 +107,8 @@
                "length": "30",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Left-justified and upper case"
           },
           "respondentAddress": {
@@ -100,6 +118,8 @@
                "length": "40",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Left-justified"
           },
           "respondentCity": {
@@ -109,6 +129,8 @@
                "length": "25",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Left-justified"
           },
           "respondentState": {
@@ -118,6 +140,8 @@
                "length": "2",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Postal Code abbreviation"
           },
           "respondentZip": {
@@ -127,6 +151,8 @@
                "length": "10",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Format is 99999 left-justified or Code 99999-9999"
           },
           "parentName": {
@@ -136,6 +162,8 @@
                "length": "30",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "If applicable"
           },
           "parentAddress": {
@@ -145,6 +173,8 @@
                "length": "40",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "If applicable"
           },
           "parentCity": {
@@ -154,6 +184,8 @@
                "length": "25",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "If applicable"
           },
           "parentState": {
@@ -163,6 +195,8 @@
                "length": "2",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "If applicable"
           },
           "parentZip": {
@@ -172,6 +206,8 @@
                "length": "10",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "If applicable; format is 99999 left-justified or 99999-9999"
           },
           "contactName": {
@@ -181,6 +217,8 @@
                "length": "30",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "For questionable data, reports, or other issues that may arise during an annual processing cycle."
           },
           "contactPhone": {
@@ -190,6 +228,8 @@
                "length": "12",
                "dataType": "AN",
                "format": "phoneNumber",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Format is 999-999-9999"
           },
           "contactFax": {
@@ -199,6 +239,8 @@
                "length": "12",
                "dataType": "AN",
                "format": "phoneNumber",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Format is 999-999-9999"
           },
           "respondentEmail": {
@@ -208,6 +250,8 @@
                "length": "66",
                "dataType": "AN",
                "format": "emailAddress",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Enter only one e-mail address. E-mail address must contain only one @ symbol. Format is left-justified."
           }
      },
@@ -219,6 +263,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Value is 2"
           },
           "respondentID": {
@@ -228,6 +274,8 @@
                "length": "10",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Assigned by your federal regulatory agency. Format is right-justified and zero-filled."
           },
           "agencyCode": {
@@ -237,6 +285,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1=OCC, 2=FRS, 3=FDIC, 5=NCUA, 7=HUD, or 9=CFPB",
                "values": {
                    "1": "OCC",
@@ -254,6 +304,8 @@
                "length": "25",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Unique identifier across the home office and branch sites"
           },
           "applicationReceivedDate": {
@@ -263,6 +315,8 @@
                "length": "8",
                "dataType": "AN",
                "format": "date",
+               "canBeBlank": false,
+               "canBeNA": true,
                "description": "Format is ccyymmdd or NA left-justified"
           },
           "loanType": {
@@ -272,6 +326,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, or 4",
                "values": {
                     "1": "Conventional (any loan other than FHA, VA, FSA, or RHS loans)",
@@ -287,6 +343,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, or 3",
                "values": {
                     "1": "One to four-family (other than manufactured housing)",
@@ -301,6 +359,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, or 3",
                "values": {
                    "1": "Home purchase",
@@ -315,6 +375,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, or 3",
                "values": {
                    "1": "Owner-occupied as a principal dwelling",
@@ -329,6 +391,8 @@
                "length": "5",
                "dataType": "N",
                "format": "currency",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas"
           },
           "preapprovals": {
@@ -338,6 +402,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, or 3",
                "values": {
                     "1": "Preapproval was requested",
@@ -352,6 +418,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, OR 8",
                "values": {
                     "1": "Loan originated",
@@ -371,6 +439,8 @@
                "length": "8",
                "dataType": "N",
                "format": "date",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Format is ccyymmdd"
           },
           "metroArea": {
@@ -380,6 +450,8 @@
                "length": "5",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": true,
+               "canBeNA": true,
                "description": "Metropolitan Statistical Area or Metropolitan Division (if appropriate) code or NA left-justified"
           },
           "fipsState": {
@@ -390,6 +462,8 @@
                "dataType": "AN",
                "format": "string",
                "description": "FIPS code with leading zerosor NA left-justified"
+               "canBeBlank": false,
+               "canBeNA": true,
           },
           "fipsCounty": {
                "label": "County Code",
@@ -398,6 +472,8 @@
                "length": "3",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": true,
                "description": "FIPS code with leading zeros or NA left-justified"
           },
           "censusTract": {
@@ -407,6 +483,8 @@
                "length": "7",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": true,
                "description": "Include decimal point and any leading or trailing zeros or NA left-justified"
           },
           "applicantEthnicity": {
@@ -416,6 +494,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, or 4",
                "values": {
                     "1": "Hispanic or Latino",
@@ -431,6 +511,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, or 5",
                "values": {
                     "1": "Hispanic or Latino",
@@ -447,6 +529,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, or 7",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -465,6 +549,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -481,6 +567,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -497,6 +585,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -513,6 +603,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -529,6 +621,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, or 8",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -548,6 +642,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -564,6 +660,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -580,6 +678,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -596,6 +696,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -612,6 +714,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, or 4",
                "values": {
                    "1": "Male",
@@ -627,6 +731,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, or 5",
                "values": {
                    "1": "Male",
@@ -643,6 +749,8 @@
                "length": "4",
                "dataType": "AN",
                "format": "currency",
+               "canBeBlank": false,
+               "canBeNA": true,
                "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas or NA left-justified"
           },
           "purchaserType": {
@@ -652,6 +760,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 0, 1, 2, 3, 4, 5, 6, 7, 8, or 9",
                "values": {
                     "0": "Loan was not originated or was not sold in calendar year covered by register",
@@ -673,6 +783,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank",
                "values": {
                    "1": "Debt-to-income ratio",
@@ -693,6 +805,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank",
                "values": {
                    "1": "Debt-to-income ratio",
@@ -713,6 +827,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank",
                "values": {
                    "1": "Debt-to-income ratio",
@@ -733,6 +849,8 @@
                "length": "5",
                "dataType": "AN",
                "format": "percent",
+               "canBeBlank": false,
+               "canBeNA": true,
                "description": "Enter the rate spread to two decimal places. Include the decimal point and any leading or trailing zeros or NA left-justified"
           },
           "hoepaStatus": {
@@ -742,6 +860,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1 or 2",
                "values": {
                     "1": "HOEPA loan",
@@ -755,6 +875,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, or 4",
                "values": {
                     "1": "Secured by a first lien",
@@ -769,6 +891,8 @@
                "end": "380",
                "length": "270",
                "dataType": "AN",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Blank"
           }
      }

--- a/2013/data_file_specification.json
+++ b/2013/data_file_specification.json
@@ -11,10 +11,12 @@
                "end": "1",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Value is 1"
+               "description": "Value is 1",
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "respondentID": {
                "label": "Respondent-ID",
@@ -22,10 +24,12 @@
                "end": "11",
                "length": "10",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Assigned by your federal regulatory agency. Format is right-justified and zero filled."
+               "description": "Assigned by your federal regulatory agency. Format is right-justified and zero filled.",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "agencyCode": {
                "label": "Agency Code",
@@ -33,17 +37,19 @@
                "end": "12",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1=OCC, 2=FRS, 3=FDIC, 5=NCUA, 7=HUD, or 9=CFPB",
-               "values": {
-                   "1": "OCC",
-                   "2": "FRS",
-                   "3": "FDIC",
-                   "5": "NCUA",
-                   "7": "HUD",
-                   "9": "CFPB"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "OCC",
+                       "2": "FRS",
+                       "3": "FDIC",
+                       "5": "NCUA",
+                       "7": "HUD",
+                       "9": "CFPB"
+                   }
                }
           },
           "timestamp": {
@@ -52,10 +58,13 @@
                "end": "24",
                "length": "12",
                "dataType": "N",
-               "format": "datetime",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Format is century, year, month, day, hour, minute (e.g., Jan. 17, 2013, at 1:30 pm would be 201301171330)"
+               "description": "Format is century, year, month, day, hour, minute (e.g., Jan. 17, 2013, at 1:30 pm would be 201301171330)",
+               "validation": {
+                   "type": "datetime",
+                   "match": "yyyyMMddHHmm",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "filler": {
                "label": "Filler",
@@ -63,9 +72,11 @@
                "end": "25",
                "length": "1",
                "dataType": "AN",
-               "canBeBlank": true,
-               "canBeNA": false,
-               "description": "Blank"
+               "description": "Blank",
+               "validation": {
+                   "canBeBlank": true,
+                   "canBeNA": false
+               }
           },
           "activityYear": {
                "label": "Activity Year",
@@ -73,10 +84,12 @@
                "end": "29",
                "length": "4",
                "dataType": "N",
-               "format": "year",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Four digit year (e.g., 2013)"
+               "description": "Four digit year (e.g., 2013)",
+               "validation": {
+                   "type": "year",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "taxID": {
                "label": "Tax ID",
@@ -84,10 +97,12 @@
                "end": "39",
                "length": "10",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Format is 99-9999999"
+               "description": "Format is 99-9999999",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "totalLineEntries": {
                "label": "Total Line Entries",
@@ -95,10 +110,12 @@
                "end": "46",
                "length": "7",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "The N of line entries contained in the accompanying Loan/Application Register"
+               "description": "The N of line entries contained in the accompanying Loan/Application Register",
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "institutionName": {
                "label": "Respondent Name",
@@ -106,10 +123,12 @@
                "end": "76",
                "length": "30",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Left-justified and upper case"
+               "description": "Left-justified and upper case",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "respondentAddress": {
                "label": "Respondent Address",
@@ -117,10 +136,12 @@
                "end": "116",
                "length": "40",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Left-justified"
+               "description": "Left-justified",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "respondentCity": {
                "label": "Respondent City",
@@ -128,10 +149,12 @@
                "end": "141",
                "length": "25",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Left-justified"
+               "description": "Left-justified",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "respondentState": {
                "label": "Respondent State",
@@ -139,10 +162,12 @@
                "end": "143",
                "length": "2",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Postal Code abbreviation"
+               "description": "Postal Code abbreviation",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "respondentZip": {
                "label": "Respondent Zip",
@@ -150,10 +175,12 @@
                "end": "153",
                "length": "10",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Format is 99999 left-justified or Code 99999-9999"
+               "description": "Format is 99999 left-justified or Code 99999-9999",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "parentName": {
                "label": "Parent Name",
@@ -161,10 +188,12 @@
                "end": "183",
                "length": "30",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": true,
-               "canBeNA": false,
-               "description": "If applicable"
+               "description": "If applicable",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": true,
+                   "canBeNA": false
+               }
           },
           "parentAddress": {
                "label": "Parent Address",
@@ -172,10 +201,12 @@
                "end": "223",
                "length": "40",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": true,
-               "canBeNA": false,
-               "description": "If applicable"
+               "description": "If applicable",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": true,
+                   "canBeNA": false
+               }
           },
           "parentCity": {
                "label": "Parent City",
@@ -183,10 +214,12 @@
                "end": "248",
                "length": "25",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": true,
-               "canBeNA": false,
-               "description": "If applicable"
+               "description": "If applicable",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": true,
+                   "canBeNA": false
+               }
           },
           "parentState": {
                "label": "Parent State",
@@ -194,10 +227,12 @@
                "end": "250",
                "length": "2",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": true,
-               "canBeNA": false,
-               "description": "If applicable"
+               "description": "If applicable",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": true,
+                   "canBeNA": false
+               }
           },
           "parentZip": {
                "label": "Parent Zip Code",
@@ -205,10 +240,12 @@
                "end": "260",
                "length": "10",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": true,
-               "canBeNA": false,
-               "description": "If applicable; format is 99999 left-justified or 99999-9999"
+               "description": "If applicable; format is 99999 left-justified or 99999-9999",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": true,
+                   "canBeNA": false
+               }
           },
           "contactName": {
                "label": "Contact Person's Name",
@@ -216,10 +253,12 @@
                "end": "290",
                "length": "30",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "For questionable data, reports, or other issues that may arise during an annual processing cycle."
+               "description": "For questionable data, reports, or other issues that may arise during an annual processing cycle.",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "contactPhone": {
                "label": "Contact Person's Phone Number",
@@ -227,10 +266,12 @@
                "end": "302",
                "length": "12",
                "dataType": "AN",
-               "format": "phoneNumber",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Format is 999-999-9999"
+               "description": "Format is 999-999-9999",
+               "validation": {
+                   "type": "phoneNumber",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "contactFax": {
                "label": "Contact Person's Facsimile Number",
@@ -238,10 +279,12 @@
                "end": "314",
                "length": "12",
                "dataType": "AN",
-               "format": "phoneNumber",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Format is 999-999-9999"
+               "description": "Format is 999-999-9999",
+               "validation": {
+                   "type": "phoneNumber",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "respondentEmail": {
                "label": "Contact Person's E-mail Address",
@@ -249,10 +292,12 @@
                "end": "380",
                "length": "66",
                "dataType": "AN",
-               "format": "emailAddress",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Enter only one e-mail address. E-mail address must contain only one @ symbol. Format is left-justified."
+               "description": "Enter only one e-mail address. E-mail address must contain only one @ symbol. Format is left-justified.",
+               "validation": {
+                   "type": "emailAddress",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           }
      },
      "loanApplicationRegister": {
@@ -262,10 +307,12 @@
                "end": "1",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Value is 2"
+               "description": "Value is 2",
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "respondentID": {
                "label": "Respondent-ID",
@@ -273,10 +320,12 @@
                "end": "11",
                "length": "10",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Assigned by your federal regulatory agency. Format is right-justified and zero-filled."
+               "description": "Assigned by your federal regulatory agency. Format is right-justified and zero-filled.",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "agencyCode": {
                "label": "Agency Code",
@@ -284,17 +333,19 @@
                "end": "12",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1=OCC, 2=FRS, 3=FDIC, 5=NCUA, 7=HUD, or 9=CFPB",
-               "values": {
-                   "1": "OCC",
-                   "2": "FRS",
-                   "3": "FDIC",
-                   "5": "NCUA",
-                   "7": "HUD",
-                   "9": "CFPB"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "OCC",
+                       "2": "FRS",
+                       "3": "FDIC",
+                       "5": "NCUA",
+                       "7": "HUD",
+                       "9": "CFPB"
+                   }
                }
           },
           "loanNumber": {
@@ -303,10 +354,12 @@
                "end": "37",
                "length": "25",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Unique identifier across the home office and branch sites"
+               "description": "Unique identifier across the home office and branch sites",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "applicationReceivedDate": {
                "label": "Date Application Received",
@@ -314,10 +367,13 @@
                "end": "45",
                "length": "8",
                "dataType": "AN",
-               "format": "date",
-               "canBeBlank": false,
-               "canBeNA": true,
-               "description": "Format is ccyymmdd or NA left-justified"
+               "description": "Format is ccyymmdd or NA left-justified",
+               "validation": {
+                   "type": "date",
+                   "match": "yyyyMMdd",
+                   "canBeBlank": false,
+                   "canBeNA": true
+               }
           },
           "loanType": {
                "label": "Loan Type",
@@ -325,15 +381,17 @@
                "end": "46",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, or 4",
-               "values": {
-                    "1": "Conventional (any loan other than FHA, VA, FSA, or RHS loans)",
-                    "2": "FHA-insured (Federal Housing Administration)",
-                    "3": "VA-guaranteed (Veterans Administration)",
-                    "4": "FSA/RHS (Farm Service Agency or Rural Housing Service)"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                        "1": "Conventional (any loan other than FHA, VA, FSA, or RHS loans)",
+                        "2": "FHA-insured (Federal Housing Administration)",
+                        "3": "VA-guaranteed (Veterans Administration)",
+                        "4": "FSA/RHS (Farm Service Agency or Rural Housing Service)"
+                   }
                }
           },
           "propertyType": {
@@ -342,14 +400,16 @@
                "end": "47",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, or 3",
-               "values": {
-                    "1": "One to four-family (other than manufactured housing)",
-                    "2": "Manufactured housing",
-                    "3": "Multifamily"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                        "1": "One to four-family (other than manufactured housing)",
+                        "2": "Manufactured housing",
+                        "3": "Multifamily"
+                   }
                }
           },
           "loanPurpose": {
@@ -358,14 +418,16 @@
                "end": "48",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, or 3",
-               "values": {
-                   "1": "Home purchase",
-                   "2": "Home improvement",
-                   "3": "Refinancing"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "Home purchase",
+                       "2": "Home improvement",
+                       "3": "Refinancing"
+                   }
                }
           },
           "ownerOccupancy": {
@@ -374,14 +436,16 @@
                "end": "49",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, or 3",
-               "values": {
-                   "1": "Owner-occupied as a principal dwelling",
-                   "2": "Not owner-occupied",
-                   "3": "Not applicable"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "Owner-occupied as a principal dwelling",
+                       "2": "Not owner-occupied",
+                       "3": "Not applicable"
+                   }
                }
           },
           "loanAmount": {
@@ -390,10 +454,13 @@
                "end": "54",
                "length": "5",
                "dataType": "N",
-               "format": "currency,thousands",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas"
+               "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas",
+               "validation": {
+                   "type": "currency",
+                   "multiplier": 1000,
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "preapprovals": {
                "label": "Preapprovals",
@@ -401,14 +468,16 @@
                "end": "55",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, or 3",
-               "values": {
-                    "1": "Preapproval was requested",
-                    "2": "Preapproval was not requested",
-                    "3": "Not applicable"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                        "1": "Preapproval was requested",
+                        "2": "Preapproval was not requested",
+                        "3": "Not applicable"
+                   }
                }
           },
           "actionTaken": {
@@ -417,19 +486,21 @@
                "end": "56",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, OR 8",
-               "values": {
-                    "1": "Loan originated",
-                    "2": "Application approved but not accepted",
-                    "3": "Application denied by financial institution",
-                    "4": "Application withdrawn by applicant",
-                    "5": "File closed for incompleteness",
-                    "6": "Loan purchased by the institution",
-                    "7": "Preapproval request denied by financial institution",
-                    "8": "Preapproval request approved but not accepted (optional reporting)"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                        "1": "Loan originated",
+                        "2": "Application approved but not accepted",
+                        "3": "Application denied by financial institution",
+                        "4": "Application withdrawn by applicant",
+                        "5": "File closed for incompleteness",
+                        "6": "Loan purchased by the institution",
+                        "7": "Preapproval request denied by financial institution",
+                        "8": "Preapproval request approved but not accepted (optional reporting)"
+                   }
                }
           },
           "actionDate": {
@@ -438,10 +509,13 @@
                "end": "64",
                "length": "8",
                "dataType": "N",
-               "format": "date",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Format is ccyymmdd"
+               "description": "Format is ccyymmdd",
+               "validation": {
+                   "type": "date",
+                   "match": "yyyyMMdd",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "metroArea": {
                "label": "Metropolitan Statistical Area/Metropolitan Division",
@@ -449,10 +523,12 @@
                "end": "69",
                "length": "5",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": true,
-               "canBeNA": true,
-               "description": "Metropolitan Statistical Area or Metropolitan Division (if appropriate) code or NA left-justified"
+               "description": "Metropolitan Statistical Area or Metropolitan Division (if appropriate) code or NA left-justified",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": true,
+                   "canBeNA": true
+               }
           },
           "fipsState": {
                "label": "State Code",
@@ -460,10 +536,12 @@
                "end": "71",
                "length": "2",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": true,
-               "description": "FIPS code with leading zeros or NA left-justified"
+               "description": "FIPS code with leading zeros or NA left-justified",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": true
+               }
           },
           "fipsCounty": {
                "label": "County Code",
@@ -471,10 +549,12 @@
                "end": "74",
                "length": "3",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": true,
-               "description": "FIPS code with leading zeros or NA left-justified"
+               "description": "FIPS code with leading zeros or NA left-justified",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": true
+               }
           },
           "censusTract": {
                "label": "Census Tract",
@@ -482,10 +562,12 @@
                "end": "81",
                "length": "7",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": true,
-               "description": "Include decimal point and any leading or trailing zeros or NA left-justified"
+               "description": "Include decimal point and any leading or trailing zeros or NA left-justified",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": true
+               }
           },
           "applicantEthnicity": {
                "label": "Applicant Ethnicity",
@@ -493,15 +575,17 @@
                "end": "82",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, or 4",
-               "values": {
-                    "1": "Hispanic or Latino",
-                    "2": "Not Hispanic or Latino",
-                    "3": "Information not provided by applicant in mail, Internet, or telephone application",
-                    "4": "Not applicable"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                        "1": "Hispanic or Latino",
+                        "2": "Not Hispanic or Latino",
+                        "3": "Information not provided by applicant in mail, Internet, or telephone application",
+                        "4": "Not applicable"
+                   }
                }
           },
           "coapplicantEthnicity": {
@@ -510,16 +594,18 @@
                "end": "83",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, or 5",
-               "values": {
-                    "1": "Hispanic or Latino",
-                    "2": "Not Hispanic or Latino",
-                    "3": "Information not provided by applicant in mail, Internet, or telephone application",
-                    "4": "Not applicable",
-                    "5": "No co-applicant"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                        "1": "Hispanic or Latino",
+                        "2": "Not Hispanic or Latino",
+                        "3": "Information not provided by applicant in mail, Internet, or telephone application",
+                        "4": "Not applicable",
+                        "5": "No co-applicant"
+                   }
                }
           },
           "applicantRace1": {
@@ -528,18 +614,20 @@
                "end": "84",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, or 7",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White",
-                   "6": "Information not provided by applicant in mail, Internet, or telephone application",
-                   "7": "Not applicable"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White",
+                       "6": "Information not provided by applicant in mail, Internet, or telephone application",
+                       "7": "Not applicable"
+                   }
                }
           },
           "applicantRace2": {
@@ -548,16 +636,18 @@
                "end": "85",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White"
+                   }
                }
           },
           "applicantRace3": {
@@ -566,16 +656,18 @@
                "end": "86",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White"
+                   }
                }
           },
           "applicantRace4": {
@@ -584,16 +676,18 @@
                "end": "87",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White"
+                   }
                }
           },
           "applicantRace5": {
@@ -602,16 +696,18 @@
                "end": "88",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White"
+                   }
                }
           },
           "coapplicantRace1": {
@@ -620,19 +716,21 @@
                "end": "89",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, or 8",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White",
-                   "6": "Information not provided by applicant in mail, Internet, or telephone application",
-                   "7": "Not applicable",
-                   "8": "No co-applicant"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White",
+                       "6": "Information not provided by applicant in mail, Internet, or telephone application",
+                       "7": "Not applicable",
+                       "8": "No co-applicant"
+                   }
                }
           },
           "coapplicantRace2": {
@@ -641,16 +739,18 @@
                "end": "90",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White"
+                   }
                }
           },
           "coapplicantRace3": {
@@ -659,16 +759,18 @@
                "end": "91",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White"
+                   }
                }
           },
           "coapplicantRace4": {
@@ -677,16 +779,18 @@
                "end": "92",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White"
+                   }
                }
           },
           "coapplicantRace5": {
@@ -695,16 +799,18 @@
                "end": "93",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White"
+                   }
                }
           },
           "applicantSex": {
@@ -713,15 +819,17 @@
                "end": "94",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, or 4",
-               "values": {
-                   "1": "Male",
-                   "2": "Female",
-                   "3": "Information not provided by applicant in mail, Internet, or telephone application",
-                   "4": "Not applicable"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "Male",
+                       "2": "Female",
+                       "3": "Information not provided by applicant in mail, Internet, or telephone application",
+                       "4": "Not applicable"
+                   }
                }
           },
           "coapplicantSex": {
@@ -730,16 +838,18 @@
                "end": "95",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, or 5",
-               "values": {
-                   "1": "Male",
-                   "2": "Female",
-                   "3": "Information not provided by applicant in mail, Internet, or telephone application",
-                   "4": "Not applicable",
-                   "5": "No co-applicant"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "Male",
+                       "2": "Female",
+                       "3": "Information not provided by applicant in mail, Internet, or telephone application",
+                       "4": "Not applicable",
+                       "5": "No co-applicant"
+                   }
                }
           },
           "applicantIncome": {
@@ -748,10 +858,13 @@
                "end": "99",
                "length": "4",
                "dataType": "AN",
-               "format": "currency,thousands",
-               "canBeBlank": false,
-               "canBeNA": true,
-               "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas or NA left-justified"
+               "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas or NA left-justified",
+               "validation": {
+                   "type": "currency",
+                   "multiplier": 1000,
+                   "canBeBlank": false,
+                   "canBeNA": true
+               }
           },
           "purchaserType": {
                "label": "Type of Purchaser",
@@ -759,21 +872,23 @@
                "end": "100",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 0, 1, 2, 3, 4, 5, 6, 7, 8, or 9",
-               "values": {
-                    "0": "Loan was not originated or was not sold in calendar year covered by register",
-                    "1": "Fannie Mae (FNMA)",
-                    "2": "Ginnie Mae (GNMA)",
-                    "3": "Freddie Mac (FHLMC)",
-                    "4": "Farmer Mac (FAMC)",
-                    "5": "Private securitization",
-                    "6": "Commercial bank, savings bank or savings association",
-                    "7": "Life insurance company, credit union, mortgage bank, or finance company",
-                    "8": "Affiliate institution",
-                    "9": "Other type of purchaser"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                        "0": "Loan was not originated or was not sold in calendar year covered by register",
+                        "1": "Fannie Mae (FNMA)",
+                        "2": "Ginnie Mae (GNMA)",
+                        "3": "Freddie Mac (FHLMC)",
+                        "4": "Farmer Mac (FAMC)",
+                        "5": "Private securitization",
+                        "6": "Commercial bank, savings bank or savings association",
+                        "7": "Life insurance company, credit union, mortgage bank, or finance company",
+                        "8": "Affiliate institution",
+                        "9": "Other type of purchaser"
+                   }
                }
           },
           "denialReason1": {
@@ -782,20 +897,22 @@
                "end": "101",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank",
-               "values": {
-                   "1": "Debt-to-income ratio",
-                   "2": "Employment history",
-                   "3": "Credit history",
-                   "4": "Collateral",
-                   "5": "Insufficient cash (downpayment, closing costs)",
-                   "6": "Unverifiable information",
-                   "7": "Credit application incomplete",
-                   "8": "Mortgage insurance denied",
-                   "9": "Other"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "Debt-to-income ratio",
+                       "2": "Employment history",
+                       "3": "Credit history",
+                       "4": "Collateral",
+                       "5": "Insufficient cash (downpayment, closing costs)",
+                       "6": "Unverifiable information",
+                       "7": "Credit application incomplete",
+                       "8": "Mortgage insurance denied",
+                       "9": "Other"
+                   }
                }
           },
           "denialReason2": {
@@ -804,20 +921,22 @@
                "end": "102",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank",
-               "values": {
-                   "1": "Debt-to-income ratio",
-                   "2": "Employment history",
-                   "3": "Credit history",
-                   "4": "Collateral",
-                   "5": "Insufficient cash (downpayment, closing costs)",
-                   "6": "Unverifiable information",
-                   "7": "Credit application incomplete",
-                   "8": "Mortgage insurance denied",
-                   "9": "Other"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "Debt-to-income ratio",
+                       "2": "Employment history",
+                       "3": "Credit history",
+                       "4": "Collateral",
+                       "5": "Insufficient cash (downpayment, closing costs)",
+                       "6": "Unverifiable information",
+                       "7": "Credit application incomplete",
+                       "8": "Mortgage insurance denied",
+                       "9": "Other"
+                   }
                }
           },
           "denialReason3": {
@@ -826,20 +945,22 @@
                "end": "103",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank",
-               "values": {
-                   "1": "Debt-to-income ratio",
-                   "2": "Employment history",
-                   "3": "Credit history",
-                   "4": "Collateral",
-                   "5": "Insufficient cash (downpayment, closing costs)",
-                   "6": "Unverifiable information",
-                   "7": "Credit application incomplete",
-                   "8": "Mortgage insurance denied",
-                   "9": "Other"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "Debt-to-income ratio",
+                       "2": "Employment history",
+                       "3": "Credit history",
+                       "4": "Collateral",
+                       "5": "Insufficient cash (downpayment, closing costs)",
+                       "6": "Unverifiable information",
+                       "7": "Credit application incomplete",
+                       "8": "Mortgage insurance denied",
+                       "9": "Other"
+                   }
                }
           },
           "rateSpread": {
@@ -848,10 +969,12 @@
                "end": "108",
                "length": "5",
                "dataType": "AN",
-               "format": "percent",
-               "canBeBlank": false,
-               "canBeNA": true,
-               "description": "Enter the rate spread to two decimal places. Include the decimal point and any leading or trailing zeros or NA left-justified"
+               "description": "Enter the rate spread to two decimal places. Include the decimal point and any leading or trailing zeros or NA left-justified",
+               "validation": {
+                   "type": "percent",
+                   "canBeBlank": false,
+                   "canBeNA": true
+               }
           },
           "hoepaStatus": {
                "label": "HOEPA Status",
@@ -859,13 +982,15 @@
                "end": "109",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1 or 2",
-               "values": {
-                    "1": "HOEPA loan",
-                    "2": "Not a HOEPA loan"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                        "1": "HOEPA loan",
+                        "2": "Not a HOEPA loan"
+                   }
                }
           },
           "lienStatus": {
@@ -874,15 +999,17 @@
                "end": "110",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, or 4",
-               "values": {
-                    "1": "Secured by a first lien",
-                    "2": "Secured by a subordinate lien",
-                    "3": "Not secured by a lien",
-                    "4": "Not applicable (purchased loans)"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                        "1": "Secured by a first lien",
+                        "2": "Secured by a subordinate lien",
+                        "3": "Not secured by a lien",
+                        "4": "Not applicable (purchased loans)"
+                   }
                }
           },
           "filler": {
@@ -891,9 +1018,11 @@
                "end": "380",
                "length": "270",
                "dataType": "AN",
-               "canBeBlank": true,
-               "canBeNA": false,
-               "description": "Blank"
+               "description": "Blank",
+               "validation": {
+                   "canBeBlank": true,
+                   "canBeNA": false
+               }
           }
      }
 }

--- a/2013/data_file_specification.json
+++ b/2013/data_file_specification.json
@@ -1,6 +1,7 @@
 {
      "metadata": {
           "src": "http://www.ffiec.gov/hmda/pdf/spec2013.pdf",
+          "values": "https://www.ffiec.gov/hmda/pdf/edit2013.pdf#page=7",
           "year": "2013"
      },
      "transmittalSheet": {

--- a/2013/data_file_specification.json
+++ b/2013/data_file_specification.json
@@ -390,7 +390,7 @@
                "end": "54",
                "length": "5",
                "dataType": "N",
-               "format": "currency",
+               "format": "currency,thousands",
                "canBeBlank": false,
                "canBeNA": false,
                "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas"
@@ -748,7 +748,7 @@
                "end": "99",
                "length": "4",
                "dataType": "AN",
-               "format": "currency",
+               "format": "currency,thousands",
                "canBeBlank": false,
                "canBeNA": true,
                "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas or NA left-justified"

--- a/2014/data_file_specification.json
+++ b/2014/data_file_specification.json
@@ -10,6 +10,7 @@
                "end": "1",
                "length": "1",
                "dataType": "N",
+               "format": "number",
                "description": "Value is 1"
           },
           "respondentID": {
@@ -18,6 +19,7 @@
                "end": "11",
                "length": "10",
                "dataType": "AN",
+               "format": "string",
                "description": "Assigned by your federal regulatory agency. Format is right-justified and zero filled."
           },
           "agencyCode": {
@@ -26,7 +28,16 @@
                "end": "12",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1=OCC, 2=FRS, 3=FDIC, 5=NCUA, 7=HUD, or 9=CFPB"
+               "format": "number",
+               "description": "Values are 1=OCC, 2=FRS, 3=FDIC, 5=NCUA, 7=HUD, or 9=CFPB",
+               "values": {
+                   "1": "OCC",
+                   "2": "FRS",
+                   "3": "FDIC",
+                   "5": "NCUA",
+                   "7": "HUD",
+                   "9": "CFPB"
+               }
           },
           "timestamp": {
                "label": "Timestamp",
@@ -34,6 +45,7 @@
                "end": "24",
                "length": "12",
                "dataType": "N",
+               "format": "datetime",
                "description": "Format is century, year, month, day, hour, minute (e.g., Jan. 17, 2013, at 1:30 pm would be 201301171330)"
           },
           "filler": {
@@ -50,6 +62,7 @@
                "end": "29",
                "length": "4",
                "dataType": "N",
+               "format": "year",
                "description": "Four digit year (e.g., 2013)"
           },
           "taxID": {
@@ -58,6 +71,7 @@
                "end": "39",
                "length": "10",
                "dataType": "AN",
+               "format": "string",
                "description": "Format is 99-9999999"
           },
           "totalLineEntries": {
@@ -66,6 +80,7 @@
                "end": "46",
                "length": "7",
                "dataType": "N",
+               "format": "number",
                "description": "The N of line entries contained in the accompanying Loan/Application Register"
           },
           "institutionName": {
@@ -74,6 +89,7 @@
                "end": "76",
                "length": "30",
                "dataType": "AN",
+               "format": "string",
                "description": "Left-justified and upper case"
           },
           "respondentAddress": {
@@ -82,6 +98,7 @@
                "end": "116",
                "length": "40",
                "dataType": "AN",
+               "format": "string",
                "description": "Left-justified"
           },
           "respondentCity": {
@@ -90,6 +107,7 @@
                "end": "141",
                "length": "25",
                "dataType": "AN",
+               "format": "string",
                "description": "Left-justified"
           },
           "respondentState": {
@@ -98,6 +116,7 @@
                "end": "143",
                "length": "2",
                "dataType": "AN",
+               "format": "string",
                "description": "Postal Code abbreviation"
           },
           "respondentZip": {
@@ -106,6 +125,7 @@
                "end": "153",
                "length": "10",
                "dataType": "AN",
+               "format": "string",
                "description": "Format is 99999 left-justified or Code 99999-9999"
           },
           "parentName": {
@@ -114,6 +134,7 @@
                "end": "183",
                "length": "30",
                "dataType": "AN",
+               "format": "string",
                "description": "If applicable"
           },
           "parentAddress": {
@@ -122,6 +143,7 @@
                "end": "223",
                "length": "40",
                "dataType": "AN",
+               "format": "string",
                "description": "If applicable"
           },
           "parentCity": {
@@ -130,6 +152,7 @@
                "end": "248",
                "length": "25",
                "dataType": "AN",
+               "format": "string",
                "description": "If applicable"
           },
           "parentState": {
@@ -138,6 +161,7 @@
                "end": "250",
                "length": "2",
                "dataType": "AN",
+               "format": "string",
                "description": "If applicable"
           },
           "parentZip": {
@@ -146,6 +170,7 @@
                "end": "260",
                "length": "10",
                "dataType": "AN",
+               "format": "string",
                "description": "If applicable; format is 99999 left-justified or 99999-9999"
           },
           "contactName": {
@@ -154,6 +179,7 @@
                "end": "290",
                "length": "30",
                "dataType": "AN",
+               "format": "string",
                "description": "For questionable data, reports, or other issues that may arise during an annual processing cycle."
           },
           "contactPhone": {
@@ -162,6 +188,7 @@
                "end": "302",
                "length": "12",
                "dataType": "AN",
+               "format": "phoneNumber",
                "description": "Format is 999-999-9999"
           },
           "contactFax": {
@@ -170,6 +197,7 @@
                "end": "314",
                "length": "12",
                "dataType": "AN",
+               "format": "phoneNumber",
                "description": "Format is 999-999-9999"
           },
           "respondentEmail": {
@@ -178,6 +206,7 @@
                "end": "380",
                "length": "66",
                "dataType": "AN",
+               "format": "emailAddress",
                "description": "Enter only one e-mail address. E-mail address must contain only one @ symbol. Format is left-justified."
           }
      },
@@ -188,6 +217,7 @@
                "end": "1",
                "length": "1",
                "dataType": "N",
+               "format": "number",
                "description": "Value is 2"
           },
           "respondentID": {
@@ -196,6 +226,7 @@
                "end": "11",
                "length": "10",
                "dataType": "AN",
+               "format": "string",
                "description": "Assigned by your federal regulatory agency. Format is right-justified and zero-filled."
           },
           "agencyCode": {
@@ -204,7 +235,16 @@
                "end": "12",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1=OCC, 2=FRS, 3=FDIC, 5=NCUA, 7=HUD, or 9=CFPB"
+               "format": "number",
+               "description": "Values are 1=OCC, 2=FRS, 3=FDIC, 5=NCUA, 7=HUD, or 9=CFPB",
+               "values": {
+                   "1": "OCC",
+                   "2": "FRS",
+                   "3": "FDIC",
+                   "5": "NCUA",
+                   "7": "HUD",
+                   "9": "CFPB"
+               }
           },
           "loanNumber": {
                "label": "Loan/Application Number",
@@ -212,6 +252,7 @@
                "end": "37",
                "length": "25",
                "dataType": "AN",
+               "format": "string",
                "description": "Unique identifier across the home office and branch sites"
           },
           "applicationReceivedDate": {
@@ -220,6 +261,7 @@
                "end": "45",
                "length": "8",
                "dataType": "AN",
+               "format": "date",
                "description": "Format is ccyymmdd or NA left-justified"
           },
           "loanType": {
@@ -228,7 +270,14 @@
                "end": "46",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, 3, or 4"
+               "format": "number",
+               "description": "Values are 1, 2, 3, or 4",
+               "values": {
+                    "1": "Conventional (any loan other than FHA, VA, FSA, or RHS loans)",
+                    "2": "FHA-insured (Federal Housing Administration)",
+                    "3": "VA-guaranteed (Veterans Administration)",
+                    "4": "FSA/RHS (Farm Service Agency or Rural Housing Service)"
+               }
           },
           "propertyType": {
                "label": "Property Type",
@@ -236,7 +285,13 @@
                "end": "47",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, or 3"
+               "format": "number",
+               "description": "Values are 1, 2, or 3",
+               "values": {
+                    "1": "One to four-family (other than manufactured housing)",
+                    "2": "Manufactured housing",
+                    "3": "Multifamily"
+               }
           },
           "loanPurpose": {
                "label": "Loan Purpose",
@@ -244,7 +299,13 @@
                "end": "48",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, or 3"
+               "format": "number",
+               "description": "Values are 1, 2, or 3",
+               "values": {
+                   "1": "Home purchase",
+                   "2": "Home improvement",
+                   "3": "Refinancing"
+               }
           },
           "ownerOccupancy": {
                "label": "Owner Occupancy",
@@ -252,7 +313,13 @@
                "end": "49",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, or 3"
+               "format": "number",
+               "description": "Values are 1, 2, or 3",
+               "values": {
+                   "1": "Owner-occupied as a principal dwelling",
+                   "2": "Not owner-occupied",
+                   "3": "Not applicable"
+               }
           },
           "loanAmount": {
                "label": "Loan Amount",
@@ -260,6 +327,7 @@
                "end": "54",
                "length": "5",
                "dataType": "N",
+               "format": "currency",
                "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas"
           },
           "preapprovals": {
@@ -268,7 +336,13 @@
                "end": "55",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, or 3"
+               "format": "number",
+               "description": "Values are 1, 2, or 3",
+               "values": {
+                    "1": "Preapproval was requested",
+                    "2": "Preapproval was not requested",
+                    "3": "Not applicable"
+               }
           },
           "actionTaken": {
                "label": "Type of Action Taken",
@@ -276,7 +350,18 @@
                "end": "56",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, 3, 4, 5, 6, 7, OR 8"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, 6, 7, OR 8",
+               "values": {
+                    "1": "Loan originated",
+                    "2": "Application approved but not accepted",
+                    "3": "Application denied by financial institution",
+                    "4": "Application withdrawn by applicant",
+                    "5": "File closed for incompleteness",
+                    "6": "Loan purchased by the institution",
+                    "7": "Preapproval request denied by financial institution",
+                    "8": "Preapproval request approved but not accepted (optional reporting)"
+               }
           },
           "actionDate": {
                "label": "Date of Action",
@@ -284,6 +369,7 @@
                "end": "64",
                "length": "8",
                "dataType": "N",
+               "format": "date",
                "description": "Format is ccyymmdd"
           },
           "metroArea": {
@@ -292,6 +378,7 @@
                "end": "69",
                "length": "5",
                "dataType": "AN",
+               "format": "string",
                "description": "Metropolitan Statistical Area or Metropolitan Division (if appropriate) code or NA left-justified"
           },
           "fipsState": {
@@ -300,6 +387,7 @@
                "end": "71",
                "length": "2",
                "dataType": "AN",
+               "format": "string",
                "description": "FIPS code with leading zerosor NA left-justified"
           },
           "fipsCounty": {
@@ -308,6 +396,7 @@
                "end": "74",
                "length": "3",
                "dataType": "AN",
+               "format": "string",
                "description": "FIPS code with leading zeros or NA left-justified"
           },
           "censusTract": {
@@ -316,6 +405,7 @@
                "end": "81",
                "length": "7",
                "dataType": "AN",
+               "format": "string",
                "description": "Include decimal point and any leading or trailing zeros or NA left-justified"
           },
           "applicantEthnicity": {
@@ -324,7 +414,14 @@
                "end": "82",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, 3, or 4"
+               "format": "number",
+               "description": "Values are 1, 2, 3, or 4",
+               "values": {
+                    "1": "Hispanic or Latino",
+                    "2": "Not Hispanic or Latino",
+                    "3": "Information not provided by applicant in mail, Internet, or telephone application",
+                    "4": "Not applicable"
+               }
           },
           "coapplicantEthnicity": {
                "label": "Co-applicant Ethnicity",
@@ -332,7 +429,15 @@
                "end": "83",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, 3, 4, or 5"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, or 5",
+               "values": {
+                    "1": "Hispanic or Latino",
+                    "2": "Not Hispanic or Latino",
+                    "3": "Information not provided by applicant in mail, Internet, or telephone application",
+                    "4": "Not applicable",
+                    "5": "No co-applicant"
+               }
           },
           "applicantRace1": {
                "label": "Applicant Race: 1",
@@ -340,7 +445,17 @@
                "end": "84",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, 3, 4, 5, 6, or 7"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, 6, or 7",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White",
+                   "6": "Information not provided by applicant in mail, Internet, or telephone application",
+                   "7": "Not applicable"
+               }
           },
           "applicantRace2": {
                "label": "Applicant Race: 2",
@@ -348,7 +463,15 @@
                "end": "85",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, or blank",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White"
+               }
           },
           "applicantRace3": {
                "label": "Applicant Race: 3",
@@ -356,7 +479,15 @@
                "end": "86",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, or blank",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White"
+               }
           },
           "applicantRace4": {
                "label": "Applicant Race: 4",
@@ -364,7 +495,15 @@
                "end": "87",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, or blank",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White"
+               }
           },
           "applicantRace5": {
                "label": "Applicant Race: 5",
@@ -372,7 +511,15 @@
                "end": "88",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, or blank",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White"
+               }
           },
           "coapplicantRace1": {
                "label": "Co-applicant Race: 1",
@@ -380,7 +527,18 @@
                "end": "89",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, 3, 4, 5, 6, 7, or 8"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, 6, 7, or 8",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White",
+                   "6": "Information not provided by applicant in mail, Internet, or telephone application",
+                   "7": "Not applicable",
+                   "8": "No co-applicant"
+               }
           },
           "coapplicantRace2": {
                "label": "Co-applicant Race: 2",
@@ -388,7 +546,15 @@
                "end": "90",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, or blank",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White"
+               }
           },
           "coapplicantRace3": {
                "label": "Co-applicant Race: 3",
@@ -396,7 +562,15 @@
                "end": "91",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, or blank",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White"
+               }
           },
           "coapplicantRace4": {
                "label": "Co-applicant Race: 4",
@@ -404,7 +578,15 @@
                "end": "92",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, or blank",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White"
+               }
           },
           "coapplicantRace5": {
                "label": "Co-applicant Race: 5",
@@ -412,7 +594,15 @@
                "end": "93",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, or blank",
+               "values": {
+                   "1": "American Indian or Alaska Native",
+                   "2": "Asian",
+                   "3": "Black or African American",
+                   "4": "Native Hawaiian or Other Pacific Islander",
+                   "5": "White"
+               }
           },
           "applicantSex": {
                "label": "Applicant Sex",
@@ -420,7 +610,14 @@
                "end": "94",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, 3, or 4"
+               "format": "number",
+               "description": "Values are 1, 2, 3, or 4",
+               "values": {
+                   "1": "Male",
+                   "2": "Female",
+                   "3": "Information not provided by applicant in mail, Internet, or telephone application",
+                   "4": "Not applicable"
+               }
           },
           "coapplicantSex": {
                "label": "Co-applicant Sex",
@@ -428,7 +625,15 @@
                "end": "95",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, 3, 4, or 5"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, or 5",
+               "values": {
+                   "1": "Male",
+                   "2": "Female",
+                   "3": "Information not provided by applicant in mail, Internet, or telephone application",
+                   "4": "Not applicable",
+                   "5": "No co-applicant"
+               }
           },
           "applicantIncome": {
                "label": "Applicant Income",
@@ -436,6 +641,7 @@
                "end": "99",
                "length": "4",
                "dataType": "AN",
+               "format": "currency",
                "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas or NA left-justified"
           },
           "purchaserType": {
@@ -444,7 +650,20 @@
                "end": "100",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 0, 1, 2, 3, 4, 5, 6, 7, 8, or 9"
+               "format": "number",
+               "description": "Values are 0, 1, 2, 3, 4, 5, 6, 7, 8, or 9",
+               "values": {
+                    "0": "Loan was not originated or was not sold in calendar year covered by register",
+                    "1": "Fannie Mae (FNMA)",
+                    "2": "Ginnie Mae (GNMA)",
+                    "3": "Freddie Mac (FHLMC)",
+                    "4": "Farmer Mac (FAMC)",
+                    "5": "Private securitization",
+                    "6": "Commercial bank, savings bank or savings association",
+                    "7": "Life insurance company, credit union, mortgage bank, or finance company",
+                    "8": "Affiliate institution",
+                    "9": "Other type of purchaser"
+               }
           },
           "denialReason1": {
                "label": "Denial Reason: 1",
@@ -452,7 +671,19 @@
                "end": "101",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank",
+               "values": {
+                   "1": "Debt-to-income ratio",
+                   "2": "Employment history",
+                   "3": "Credit history",
+                   "4": "Collateral",
+                   "5": "Insufficient cash (downpayment, closing costs)",
+                   "6": "Unverifiable information",
+                   "7": "Credit application incomplete",
+                   "8": "Mortgage insurance denied",
+                   "9": "Other"
+               }
           },
           "denialReason2": {
                "label": "Denial Reason: 2",
@@ -460,7 +691,19 @@
                "end": "102",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank",
+               "values": {
+                   "1": "Debt-to-income ratio",
+                   "2": "Employment history",
+                   "3": "Credit history",
+                   "4": "Collateral",
+                   "5": "Insufficient cash (downpayment, closing costs)",
+                   "6": "Unverifiable information",
+                   "7": "Credit application incomplete",
+                   "8": "Mortgage insurance denied",
+                   "9": "Other"
+               }
           },
           "denialReason3": {
                "label": "Denial Reason: 3",
@@ -468,7 +711,19 @@
                "end": "103",
                "length": "1",
                "dataType": "AN",
-               "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank"
+               "format": "number",
+               "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank",
+               "values": {
+                   "1": "Debt-to-income ratio",
+                   "2": "Employment history",
+                   "3": "Credit history",
+                   "4": "Collateral",
+                   "5": "Insufficient cash (downpayment, closing costs)",
+                   "6": "Unverifiable information",
+                   "7": "Credit application incomplete",
+                   "8": "Mortgage insurance denied",
+                   "9": "Other"
+               }
           },
           "rateSpread": {
                "label": "Rate Spread",
@@ -476,6 +731,7 @@
                "end": "108",
                "length": "5",
                "dataType": "AN",
+               "format": "percent",
                "description": "Enter the rate spread to two decimal places. Include the decimal point and any leading or trailing zeros or NA left-justified"
           },
           "hoepaStatus": {
@@ -484,7 +740,12 @@
                "end": "109",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1 or 2"
+               "format": "number",
+               "description": "Values are 1 or 2",
+               "values": {
+                    "1": "HOEPA loan",
+                    "2": "Not a HOEPA loan"
+               }
           },
           "lienStatus": {
                "label": "Lien Status",
@@ -492,7 +753,14 @@
                "end": "110",
                "length": "1",
                "dataType": "N",
-               "description": "Values are 1, 2, 3, or 4"
+               "format": "number",
+               "description": "Values are 1, 2, 3, or 4",
+               "values": {
+                    "1": "Secured by a first lien",
+                    "2": "Secured by a subordinate lien",
+                    "3": "Not secured by a lien",
+                    "4": "Not applicable (purchased loans)"
+               }
           },
           "filler": {
                "label": "Filler",

--- a/2014/data_file_specification.json
+++ b/2014/data_file_specification.json
@@ -60,7 +60,7 @@
                "dataType": "N",
                "description": "Format is century, year, month, day, hour, minute (e.g., Jan. 17, 2013, at 1:30 pm would be 201301171330)",
                "validation": {
-                   "type": "datetime",
+                   "type": "date",
                    "match": "yyyyMMddHHmm",
                    "canBeBlank": false,
                    "canBeNA": false
@@ -86,7 +86,8 @@
                "dataType": "N",
                "description": "Four digit year (e.g., 2013)",
                "validation": {
-                   "type": "year",
+                   "type": "date",
+                   "match": "yyyy",
                    "canBeBlank": false,
                    "canBeNA": false
                }

--- a/2014/data_file_specification.json
+++ b/2014/data_file_specification.json
@@ -461,9 +461,9 @@
                "length": "2",
                "dataType": "AN",
                "format": "string",
-               "description": "FIPS code with leading zerosor NA left-justified"
                "canBeBlank": false,
                "canBeNA": true,
+               "description": "FIPS code with leading zeros or NA left-justified"
           },
           "fipsCounty": {
                "label": "County Code",

--- a/2014/data_file_specification.json
+++ b/2014/data_file_specification.json
@@ -12,6 +12,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Value is 1"
           },
           "respondentID": {
@@ -21,6 +23,8 @@
                "length": "10",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Assigned by your federal regulatory agency. Format is right-justified and zero filled."
           },
           "agencyCode": {
@@ -30,6 +34,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1=OCC, 2=FRS, 3=FDIC, 5=NCUA, 7=HUD, or 9=CFPB",
                "values": {
                    "1": "OCC",
@@ -47,6 +53,8 @@
                "length": "12",
                "dataType": "N",
                "format": "datetime",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Format is century, year, month, day, hour, minute (e.g., Jan. 17, 2013, at 1:30 pm would be 201301171330)"
           },
           "filler": {
@@ -55,6 +63,8 @@
                "end": "25",
                "length": "1",
                "dataType": "AN",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Blank"
           },
           "activityYear": {
@@ -64,6 +74,8 @@
                "length": "4",
                "dataType": "N",
                "format": "year",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Four digit year (e.g., 2013)"
           },
           "taxID": {
@@ -73,6 +85,8 @@
                "length": "10",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Format is 99-9999999"
           },
           "totalLineEntries": {
@@ -82,6 +96,8 @@
                "length": "7",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "The N of line entries contained in the accompanying Loan/Application Register"
           },
           "institutionName": {
@@ -91,6 +107,8 @@
                "length": "30",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Left-justified and upper case"
           },
           "respondentAddress": {
@@ -100,6 +118,8 @@
                "length": "40",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Left-justified"
           },
           "respondentCity": {
@@ -109,6 +129,8 @@
                "length": "25",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Left-justified"
           },
           "respondentState": {
@@ -118,6 +140,8 @@
                "length": "2",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Postal Code abbreviation"
           },
           "respondentZip": {
@@ -127,6 +151,8 @@
                "length": "10",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Format is 99999 left-justified or Code 99999-9999"
           },
           "parentName": {
@@ -136,6 +162,8 @@
                "length": "30",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "If applicable"
           },
           "parentAddress": {
@@ -145,6 +173,8 @@
                "length": "40",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "If applicable"
           },
           "parentCity": {
@@ -154,6 +184,8 @@
                "length": "25",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "If applicable"
           },
           "parentState": {
@@ -163,6 +195,8 @@
                "length": "2",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "If applicable"
           },
           "parentZip": {
@@ -172,6 +206,8 @@
                "length": "10",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "If applicable; format is 99999 left-justified or 99999-9999"
           },
           "contactName": {
@@ -181,6 +217,8 @@
                "length": "30",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "For questionable data, reports, or other issues that may arise during an annual processing cycle."
           },
           "contactPhone": {
@@ -190,6 +228,8 @@
                "length": "12",
                "dataType": "AN",
                "format": "phoneNumber",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Format is 999-999-9999"
           },
           "contactFax": {
@@ -199,6 +239,8 @@
                "length": "12",
                "dataType": "AN",
                "format": "phoneNumber",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Format is 999-999-9999"
           },
           "respondentEmail": {
@@ -208,6 +250,8 @@
                "length": "66",
                "dataType": "AN",
                "format": "emailAddress",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Enter only one e-mail address. E-mail address must contain only one @ symbol. Format is left-justified."
           }
      },
@@ -219,6 +263,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Value is 2"
           },
           "respondentID": {
@@ -228,6 +274,8 @@
                "length": "10",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Assigned by your federal regulatory agency. Format is right-justified and zero-filled."
           },
           "agencyCode": {
@@ -237,6 +285,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1=OCC, 2=FRS, 3=FDIC, 5=NCUA, 7=HUD, or 9=CFPB",
                "values": {
                    "1": "OCC",
@@ -254,6 +304,8 @@
                "length": "25",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Unique identifier across the home office and branch sites"
           },
           "applicationReceivedDate": {
@@ -263,6 +315,8 @@
                "length": "8",
                "dataType": "AN",
                "format": "date",
+               "canBeBlank": false,
+               "canBeNA": true,
                "description": "Format is ccyymmdd or NA left-justified"
           },
           "loanType": {
@@ -272,6 +326,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, or 4",
                "values": {
                     "1": "Conventional (any loan other than FHA, VA, FSA, or RHS loans)",
@@ -287,6 +343,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, or 3",
                "values": {
                     "1": "One to four-family (other than manufactured housing)",
@@ -301,6 +359,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, or 3",
                "values": {
                    "1": "Home purchase",
@@ -315,6 +375,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, or 3",
                "values": {
                    "1": "Owner-occupied as a principal dwelling",
@@ -329,6 +391,8 @@
                "length": "5",
                "dataType": "N",
                "format": "currency",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas"
           },
           "preapprovals": {
@@ -338,6 +402,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, or 3",
                "values": {
                     "1": "Preapproval was requested",
@@ -352,6 +418,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, OR 8",
                "values": {
                     "1": "Loan originated",
@@ -371,6 +439,8 @@
                "length": "8",
                "dataType": "N",
                "format": "date",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Format is ccyymmdd"
           },
           "metroArea": {
@@ -380,6 +450,8 @@
                "length": "5",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": true,
+               "canBeNA": true,
                "description": "Metropolitan Statistical Area or Metropolitan Division (if appropriate) code or NA left-justified"
           },
           "fipsState": {
@@ -390,6 +462,8 @@
                "dataType": "AN",
                "format": "string",
                "description": "FIPS code with leading zerosor NA left-justified"
+               "canBeBlank": false,
+               "canBeNA": true,
           },
           "fipsCounty": {
                "label": "County Code",
@@ -398,6 +472,8 @@
                "length": "3",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": true,
                "description": "FIPS code with leading zeros or NA left-justified"
           },
           "censusTract": {
@@ -407,6 +483,8 @@
                "length": "7",
                "dataType": "AN",
                "format": "string",
+               "canBeBlank": false,
+               "canBeNA": true,
                "description": "Include decimal point and any leading or trailing zeros or NA left-justified"
           },
           "applicantEthnicity": {
@@ -416,6 +494,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, or 4",
                "values": {
                     "1": "Hispanic or Latino",
@@ -431,6 +511,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, or 5",
                "values": {
                     "1": "Hispanic or Latino",
@@ -447,6 +529,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, or 7",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -465,6 +549,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -481,6 +567,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -497,6 +585,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -513,6 +603,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -529,6 +621,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, or 8",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -548,6 +642,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -564,6 +660,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -580,6 +678,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -596,6 +696,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
                "values": {
                    "1": "American Indian or Alaska Native",
@@ -612,6 +714,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, or 4",
                "values": {
                    "1": "Male",
@@ -627,6 +731,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, or 5",
                "values": {
                    "1": "Male",
@@ -643,6 +749,8 @@
                "length": "4",
                "dataType": "AN",
                "format": "currency",
+               "canBeBlank": false,
+               "canBeNA": true,
                "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas or NA left-justified"
           },
           "purchaserType": {
@@ -652,6 +760,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 0, 1, 2, 3, 4, 5, 6, 7, 8, or 9",
                "values": {
                     "0": "Loan was not originated or was not sold in calendar year covered by register",
@@ -673,6 +783,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank",
                "values": {
                    "1": "Debt-to-income ratio",
@@ -693,6 +805,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank",
                "values": {
                    "1": "Debt-to-income ratio",
@@ -713,6 +827,8 @@
                "length": "1",
                "dataType": "AN",
                "format": "number",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank",
                "values": {
                    "1": "Debt-to-income ratio",
@@ -733,6 +849,8 @@
                "length": "5",
                "dataType": "AN",
                "format": "percent",
+               "canBeBlank": false,
+               "canBeNA": true,
                "description": "Enter the rate spread to two decimal places. Include the decimal point and any leading or trailing zeros or NA left-justified"
           },
           "hoepaStatus": {
@@ -742,6 +860,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1 or 2",
                "values": {
                     "1": "HOEPA loan",
@@ -755,6 +875,8 @@
                "length": "1",
                "dataType": "N",
                "format": "number",
+               "canBeBlank": false,
+               "canBeNA": false,
                "description": "Values are 1, 2, 3, or 4",
                "values": {
                     "1": "Secured by a first lien",
@@ -769,6 +891,8 @@
                "end": "380",
                "length": "270",
                "dataType": "AN",
+               "canBeBlank": true,
+               "canBeNA": false,
                "description": "Blank"
           }
      }

--- a/2014/data_file_specification.json
+++ b/2014/data_file_specification.json
@@ -11,10 +11,12 @@
                "end": "1",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Value is 1"
+               "description": "Value is 1",
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "respondentID": {
                "label": "Respondent-ID",
@@ -22,10 +24,12 @@
                "end": "11",
                "length": "10",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Assigned by your federal regulatory agency. Format is right-justified and zero filled."
+               "description": "Assigned by your federal regulatory agency. Format is right-justified and zero filled.",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "agencyCode": {
                "label": "Agency Code",
@@ -33,17 +37,19 @@
                "end": "12",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1=OCC, 2=FRS, 3=FDIC, 5=NCUA, 7=HUD, or 9=CFPB",
-               "values": {
-                   "1": "OCC",
-                   "2": "FRS",
-                   "3": "FDIC",
-                   "5": "NCUA",
-                   "7": "HUD",
-                   "9": "CFPB"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "OCC",
+                       "2": "FRS",
+                       "3": "FDIC",
+                       "5": "NCUA",
+                       "7": "HUD",
+                       "9": "CFPB"
+                   }
                }
           },
           "timestamp": {
@@ -52,10 +58,13 @@
                "end": "24",
                "length": "12",
                "dataType": "N",
-               "format": "datetime",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Format is century, year, month, day, hour, minute (e.g., Jan. 17, 2013, at 1:30 pm would be 201301171330)"
+               "description": "Format is century, year, month, day, hour, minute (e.g., Jan. 17, 2013, at 1:30 pm would be 201301171330)",
+               "validation": {
+                   "type": "datetime",
+                   "match": "yyyyMMddHHmm",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "filler": {
                "label": "Filler",
@@ -63,9 +72,11 @@
                "end": "25",
                "length": "1",
                "dataType": "AN",
-               "canBeBlank": true,
-               "canBeNA": false,
-               "description": "Blank"
+               "description": "Blank",
+               "validation": {
+                   "canBeBlank": true,
+                   "canBeNA": false
+               }
           },
           "activityYear": {
                "label": "Activity Year",
@@ -73,10 +84,12 @@
                "end": "29",
                "length": "4",
                "dataType": "N",
-               "format": "year",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Four digit year (e.g., 2013)"
+               "description": "Four digit year (e.g., 2013)",
+               "validation": {
+                   "type": "year",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "taxID": {
                "label": "Tax ID",
@@ -84,10 +97,12 @@
                "end": "39",
                "length": "10",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Format is 99-9999999"
+               "description": "Format is 99-9999999",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "totalLineEntries": {
                "label": "Total Line Entries",
@@ -95,10 +110,12 @@
                "end": "46",
                "length": "7",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "The N of line entries contained in the accompanying Loan/Application Register"
+               "description": "The N of line entries contained in the accompanying Loan/Application Register",
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "institutionName": {
                "label": "Respondent Name",
@@ -106,10 +123,12 @@
                "end": "76",
                "length": "30",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Left-justified and upper case"
+               "description": "Left-justified and upper case",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "respondentAddress": {
                "label": "Respondent Address",
@@ -117,10 +136,12 @@
                "end": "116",
                "length": "40",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Left-justified"
+               "description": "Left-justified",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "respondentCity": {
                "label": "Respondent City",
@@ -128,10 +149,12 @@
                "end": "141",
                "length": "25",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Left-justified"
+               "description": "Left-justified",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "respondentState": {
                "label": "Respondent State",
@@ -139,10 +162,12 @@
                "end": "143",
                "length": "2",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Postal Code abbreviation"
+               "description": "Postal Code abbreviation",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "respondentZip": {
                "label": "Respondent Zip",
@@ -150,10 +175,12 @@
                "end": "153",
                "length": "10",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Format is 99999 left-justified or Code 99999-9999"
+               "description": "Format is 99999 left-justified or Code 99999-9999",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "parentName": {
                "label": "Parent Name",
@@ -161,10 +188,12 @@
                "end": "183",
                "length": "30",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": true,
-               "canBeNA": false,
-               "description": "If applicable"
+               "description": "If applicable",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": true,
+                   "canBeNA": false
+               }
           },
           "parentAddress": {
                "label": "Parent Address",
@@ -172,10 +201,12 @@
                "end": "223",
                "length": "40",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": true,
-               "canBeNA": false,
-               "description": "If applicable"
+               "description": "If applicable",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": true,
+                   "canBeNA": false
+               }
           },
           "parentCity": {
                "label": "Parent City",
@@ -183,10 +214,12 @@
                "end": "248",
                "length": "25",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": true,
-               "canBeNA": false,
-               "description": "If applicable"
+               "description": "If applicable",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": true,
+                   "canBeNA": false
+               }
           },
           "parentState": {
                "label": "Parent State",
@@ -194,10 +227,12 @@
                "end": "250",
                "length": "2",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": true,
-               "canBeNA": false,
-               "description": "If applicable"
+               "description": "If applicable",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": true,
+                   "canBeNA": false
+               }
           },
           "parentZip": {
                "label": "Parent Zip Code",
@@ -205,10 +240,12 @@
                "end": "260",
                "length": "10",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": true,
-               "canBeNA": false,
-               "description": "If applicable; format is 99999 left-justified or 99999-9999"
+               "description": "If applicable; format is 99999 left-justified or 99999-9999",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": true,
+                   "canBeNA": false
+               }
           },
           "contactName": {
                "label": "Contact Person's Name",
@@ -216,10 +253,12 @@
                "end": "290",
                "length": "30",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "For questionable data, reports, or other issues that may arise during an annual processing cycle."
+               "description": "For questionable data, reports, or other issues that may arise during an annual processing cycle.",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "contactPhone": {
                "label": "Contact Person's Phone Number",
@@ -227,10 +266,12 @@
                "end": "302",
                "length": "12",
                "dataType": "AN",
-               "format": "phoneNumber",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Format is 999-999-9999"
+               "description": "Format is 999-999-9999",
+               "validation": {
+                   "type": "phoneNumber",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "contactFax": {
                "label": "Contact Person's Facsimile Number",
@@ -238,10 +279,12 @@
                "end": "314",
                "length": "12",
                "dataType": "AN",
-               "format": "phoneNumber",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Format is 999-999-9999"
+               "description": "Format is 999-999-9999",
+               "validation": {
+                   "type": "phoneNumber",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "respondentEmail": {
                "label": "Contact Person's E-mail Address",
@@ -249,10 +292,12 @@
                "end": "380",
                "length": "66",
                "dataType": "AN",
-               "format": "emailAddress",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Enter only one e-mail address. E-mail address must contain only one @ symbol. Format is left-justified."
+               "description": "Enter only one e-mail address. E-mail address must contain only one @ symbol. Format is left-justified.",
+               "validation": {
+                   "type": "emailAddress",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           }
      },
      "loanApplicationRegister": {
@@ -262,10 +307,12 @@
                "end": "1",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Value is 2"
+               "description": "Value is 2",
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "respondentID": {
                "label": "Respondent-ID",
@@ -273,10 +320,12 @@
                "end": "11",
                "length": "10",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Assigned by your federal regulatory agency. Format is right-justified and zero-filled."
+               "description": "Assigned by your federal regulatory agency. Format is right-justified and zero-filled.",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "agencyCode": {
                "label": "Agency Code",
@@ -284,17 +333,19 @@
                "end": "12",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1=OCC, 2=FRS, 3=FDIC, 5=NCUA, 7=HUD, or 9=CFPB",
-               "values": {
-                   "1": "OCC",
-                   "2": "FRS",
-                   "3": "FDIC",
-                   "5": "NCUA",
-                   "7": "HUD",
-                   "9": "CFPB"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "OCC",
+                       "2": "FRS",
+                       "3": "FDIC",
+                       "5": "NCUA",
+                       "7": "HUD",
+                       "9": "CFPB"
+                   }
                }
           },
           "loanNumber": {
@@ -303,10 +354,12 @@
                "end": "37",
                "length": "25",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Unique identifier across the home office and branch sites"
+               "description": "Unique identifier across the home office and branch sites",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "applicationReceivedDate": {
                "label": "Date Application Received",
@@ -314,10 +367,13 @@
                "end": "45",
                "length": "8",
                "dataType": "AN",
-               "format": "date",
-               "canBeBlank": false,
-               "canBeNA": true,
-               "description": "Format is ccyymmdd or NA left-justified"
+               "description": "Format is ccyymmdd or NA left-justified",
+               "validation": {
+                   "type": "date",
+                   "match": "yyyyMMdd",
+                   "canBeBlank": false,
+                   "canBeNA": true
+               }
           },
           "loanType": {
                "label": "Loan Type",
@@ -325,15 +381,17 @@
                "end": "46",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, or 4",
-               "values": {
-                    "1": "Conventional (any loan other than FHA, VA, FSA, or RHS loans)",
-                    "2": "FHA-insured (Federal Housing Administration)",
-                    "3": "VA-guaranteed (Veterans Administration)",
-                    "4": "FSA/RHS (Farm Service Agency or Rural Housing Service)"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                        "1": "Conventional (any loan other than FHA, VA, FSA, or RHS loans)",
+                        "2": "FHA-insured (Federal Housing Administration)",
+                        "3": "VA-guaranteed (Veterans Administration)",
+                        "4": "FSA/RHS (Farm Service Agency or Rural Housing Service)"
+                   }
                }
           },
           "propertyType": {
@@ -342,14 +400,16 @@
                "end": "47",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, or 3",
-               "values": {
-                    "1": "One to four-family (other than manufactured housing)",
-                    "2": "Manufactured housing",
-                    "3": "Multifamily"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                        "1": "One to four-family (other than manufactured housing)",
+                        "2": "Manufactured housing",
+                        "3": "Multifamily"
+                   }
                }
           },
           "loanPurpose": {
@@ -358,14 +418,16 @@
                "end": "48",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, or 3",
-               "values": {
-                   "1": "Home purchase",
-                   "2": "Home improvement",
-                   "3": "Refinancing"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "Home purchase",
+                       "2": "Home improvement",
+                       "3": "Refinancing"
+                   }
                }
           },
           "ownerOccupancy": {
@@ -374,14 +436,16 @@
                "end": "49",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, or 3",
-               "values": {
-                   "1": "Owner-occupied as a principal dwelling",
-                   "2": "Not owner-occupied",
-                   "3": "Not applicable"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "Owner-occupied as a principal dwelling",
+                       "2": "Not owner-occupied",
+                       "3": "Not applicable"
+                   }
                }
           },
           "loanAmount": {
@@ -390,10 +454,13 @@
                "end": "54",
                "length": "5",
                "dataType": "N",
-               "format": "currency,thousands",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas"
+               "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas",
+               "validation": {
+                   "type": "currency",
+                   "multiplier": 1000,
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "preapprovals": {
                "label": "Preapprovals",
@@ -401,14 +468,16 @@
                "end": "55",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, or 3",
-               "values": {
-                    "1": "Preapproval was requested",
-                    "2": "Preapproval was not requested",
-                    "3": "Not applicable"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                        "1": "Preapproval was requested",
+                        "2": "Preapproval was not requested",
+                        "3": "Not applicable"
+                   }
                }
           },
           "actionTaken": {
@@ -417,19 +486,21 @@
                "end": "56",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, OR 8",
-               "values": {
-                    "1": "Loan originated",
-                    "2": "Application approved but not accepted",
-                    "3": "Application denied by financial institution",
-                    "4": "Application withdrawn by applicant",
-                    "5": "File closed for incompleteness",
-                    "6": "Loan purchased by the institution",
-                    "7": "Preapproval request denied by financial institution",
-                    "8": "Preapproval request approved but not accepted (optional reporting)"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                        "1": "Loan originated",
+                        "2": "Application approved but not accepted",
+                        "3": "Application denied by financial institution",
+                        "4": "Application withdrawn by applicant",
+                        "5": "File closed for incompleteness",
+                        "6": "Loan purchased by the institution",
+                        "7": "Preapproval request denied by financial institution",
+                        "8": "Preapproval request approved but not accepted (optional reporting)"
+                   }
                }
           },
           "actionDate": {
@@ -438,10 +509,13 @@
                "end": "64",
                "length": "8",
                "dataType": "N",
-               "format": "date",
-               "canBeBlank": false,
-               "canBeNA": false,
-               "description": "Format is ccyymmdd"
+               "description": "Format is ccyymmdd",
+               "validation": {
+                   "type": "date",
+                   "match": "yyyyMMdd",
+                   "canBeBlank": false,
+                   "canBeNA": false
+               }
           },
           "metroArea": {
                "label": "Metropolitan Statistical Area/Metropolitan Division",
@@ -449,10 +523,12 @@
                "end": "69",
                "length": "5",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": true,
-               "canBeNA": true,
-               "description": "Metropolitan Statistical Area or Metropolitan Division (if appropriate) code or NA left-justified"
+               "description": "Metropolitan Statistical Area or Metropolitan Division (if appropriate) code or NA left-justified",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": true,
+                   "canBeNA": true
+               }
           },
           "fipsState": {
                "label": "State Code",
@@ -460,10 +536,12 @@
                "end": "71",
                "length": "2",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": true,
-               "description": "FIPS code with leading zeros or NA left-justified"
+               "description": "FIPS code with leading zeros or NA left-justified",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": true
+               }
           },
           "fipsCounty": {
                "label": "County Code",
@@ -471,10 +549,12 @@
                "end": "74",
                "length": "3",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": true,
-               "description": "FIPS code with leading zeros or NA left-justified"
+               "description": "FIPS code with leading zeros or NA left-justified",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": true
+               }
           },
           "censusTract": {
                "label": "Census Tract",
@@ -482,10 +562,12 @@
                "end": "81",
                "length": "7",
                "dataType": "AN",
-               "format": "string",
-               "canBeBlank": false,
-               "canBeNA": true,
-               "description": "Include decimal point and any leading or trailing zeros or NA left-justified"
+               "description": "Include decimal point and any leading or trailing zeros or NA left-justified",
+               "validation": {
+                   "type": "string",
+                   "canBeBlank": false,
+                   "canBeNA": true
+               }
           },
           "applicantEthnicity": {
                "label": "Applicant Ethnicity",
@@ -493,15 +575,17 @@
                "end": "82",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, or 4",
-               "values": {
-                    "1": "Hispanic or Latino",
-                    "2": "Not Hispanic or Latino",
-                    "3": "Information not provided by applicant in mail, Internet, or telephone application",
-                    "4": "Not applicable"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                        "1": "Hispanic or Latino",
+                        "2": "Not Hispanic or Latino",
+                        "3": "Information not provided by applicant in mail, Internet, or telephone application",
+                        "4": "Not applicable"
+                   }
                }
           },
           "coapplicantEthnicity": {
@@ -510,16 +594,18 @@
                "end": "83",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, or 5",
-               "values": {
-                    "1": "Hispanic or Latino",
-                    "2": "Not Hispanic or Latino",
-                    "3": "Information not provided by applicant in mail, Internet, or telephone application",
-                    "4": "Not applicable",
-                    "5": "No co-applicant"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                        "1": "Hispanic or Latino",
+                        "2": "Not Hispanic or Latino",
+                        "3": "Information not provided by applicant in mail, Internet, or telephone application",
+                        "4": "Not applicable",
+                        "5": "No co-applicant"
+                   }
                }
           },
           "applicantRace1": {
@@ -528,18 +614,20 @@
                "end": "84",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, or 7",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White",
-                   "6": "Information not provided by applicant in mail, Internet, or telephone application",
-                   "7": "Not applicable"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White",
+                       "6": "Information not provided by applicant in mail, Internet, or telephone application",
+                       "7": "Not applicable"
+                   }
                }
           },
           "applicantRace2": {
@@ -548,16 +636,18 @@
                "end": "85",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White"
+                   }
                }
           },
           "applicantRace3": {
@@ -566,16 +656,18 @@
                "end": "86",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White"
+                   }
                }
           },
           "applicantRace4": {
@@ -584,16 +676,18 @@
                "end": "87",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White"
+                   }
                }
           },
           "applicantRace5": {
@@ -602,16 +696,18 @@
                "end": "88",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White"
+                   }
                }
           },
           "coapplicantRace1": {
@@ -620,19 +716,21 @@
                "end": "89",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, or 8",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White",
-                   "6": "Information not provided by applicant in mail, Internet, or telephone application",
-                   "7": "Not applicable",
-                   "8": "No co-applicant"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White",
+                       "6": "Information not provided by applicant in mail, Internet, or telephone application",
+                       "7": "Not applicable",
+                       "8": "No co-applicant"
+                   }
                }
           },
           "coapplicantRace2": {
@@ -641,16 +739,18 @@
                "end": "90",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White"
+                   }
                }
           },
           "coapplicantRace3": {
@@ -659,16 +759,18 @@
                "end": "91",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White"
+                   }
                }
           },
           "coapplicantRace4": {
@@ -677,16 +779,18 @@
                "end": "92",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White"
+                   }
                }
           },
           "coapplicantRace5": {
@@ -695,16 +799,18 @@
                "end": "93",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, or blank",
-               "values": {
-                   "1": "American Indian or Alaska Native",
-                   "2": "Asian",
-                   "3": "Black or African American",
-                   "4": "Native Hawaiian or Other Pacific Islander",
-                   "5": "White"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "American Indian or Alaska Native",
+                       "2": "Asian",
+                       "3": "Black or African American",
+                       "4": "Native Hawaiian or Other Pacific Islander",
+                       "5": "White"
+                   }
                }
           },
           "applicantSex": {
@@ -713,15 +819,17 @@
                "end": "94",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, or 4",
-               "values": {
-                   "1": "Male",
-                   "2": "Female",
-                   "3": "Information not provided by applicant in mail, Internet, or telephone application",
-                   "4": "Not applicable"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "Male",
+                       "2": "Female",
+                       "3": "Information not provided by applicant in mail, Internet, or telephone application",
+                       "4": "Not applicable"
+                   }
                }
           },
           "coapplicantSex": {
@@ -730,16 +838,18 @@
                "end": "95",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, or 5",
-               "values": {
-                   "1": "Male",
-                   "2": "Female",
-                   "3": "Information not provided by applicant in mail, Internet, or telephone application",
-                   "4": "Not applicable",
-                   "5": "No co-applicant"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "Male",
+                       "2": "Female",
+                       "3": "Information not provided by applicant in mail, Internet, or telephone application",
+                       "4": "Not applicable",
+                       "5": "No co-applicant"
+                   }
                }
           },
           "applicantIncome": {
@@ -748,10 +858,13 @@
                "end": "99",
                "length": "4",
                "dataType": "AN",
-               "format": "currency,thousands",
-               "canBeBlank": false,
-               "canBeNA": true,
-               "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas or NA left-justified"
+               "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas or NA left-justified",
+               "validation": {
+                   "type": "currency",
+                   "multiplier": 1000,
+                   "canBeBlank": false,
+                   "canBeNA": true
+               }
           },
           "purchaserType": {
                "label": "Type of Purchaser",
@@ -759,21 +872,23 @@
                "end": "100",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 0, 1, 2, 3, 4, 5, 6, 7, 8, or 9",
-               "values": {
-                    "0": "Loan was not originated or was not sold in calendar year covered by register",
-                    "1": "Fannie Mae (FNMA)",
-                    "2": "Ginnie Mae (GNMA)",
-                    "3": "Freddie Mac (FHLMC)",
-                    "4": "Farmer Mac (FAMC)",
-                    "5": "Private securitization",
-                    "6": "Commercial bank, savings bank or savings association",
-                    "7": "Life insurance company, credit union, mortgage bank, or finance company",
-                    "8": "Affiliate institution",
-                    "9": "Other type of purchaser"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                        "0": "Loan was not originated or was not sold in calendar year covered by register",
+                        "1": "Fannie Mae (FNMA)",
+                        "2": "Ginnie Mae (GNMA)",
+                        "3": "Freddie Mac (FHLMC)",
+                        "4": "Farmer Mac (FAMC)",
+                        "5": "Private securitization",
+                        "6": "Commercial bank, savings bank or savings association",
+                        "7": "Life insurance company, credit union, mortgage bank, or finance company",
+                        "8": "Affiliate institution",
+                        "9": "Other type of purchaser"
+                   }
                }
           },
           "denialReason1": {
@@ -782,20 +897,22 @@
                "end": "101",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank",
-               "values": {
-                   "1": "Debt-to-income ratio",
-                   "2": "Employment history",
-                   "3": "Credit history",
-                   "4": "Collateral",
-                   "5": "Insufficient cash (downpayment, closing costs)",
-                   "6": "Unverifiable information",
-                   "7": "Credit application incomplete",
-                   "8": "Mortgage insurance denied",
-                   "9": "Other"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "Debt-to-income ratio",
+                       "2": "Employment history",
+                       "3": "Credit history",
+                       "4": "Collateral",
+                       "5": "Insufficient cash (downpayment, closing costs)",
+                       "6": "Unverifiable information",
+                       "7": "Credit application incomplete",
+                       "8": "Mortgage insurance denied",
+                       "9": "Other"
+                   }
                }
           },
           "denialReason2": {
@@ -804,20 +921,22 @@
                "end": "102",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank",
-               "values": {
-                   "1": "Debt-to-income ratio",
-                   "2": "Employment history",
-                   "3": "Credit history",
-                   "4": "Collateral",
-                   "5": "Insufficient cash (downpayment, closing costs)",
-                   "6": "Unverifiable information",
-                   "7": "Credit application incomplete",
-                   "8": "Mortgage insurance denied",
-                   "9": "Other"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "Debt-to-income ratio",
+                       "2": "Employment history",
+                       "3": "Credit history",
+                       "4": "Collateral",
+                       "5": "Insufficient cash (downpayment, closing costs)",
+                       "6": "Unverifiable information",
+                       "7": "Credit application incomplete",
+                       "8": "Mortgage insurance denied",
+                       "9": "Other"
+                   }
                }
           },
           "denialReason3": {
@@ -826,20 +945,22 @@
                "end": "103",
                "length": "1",
                "dataType": "AN",
-               "format": "number",
-               "canBeBlank": true,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, 4, 5, 6, 7, 8, 9, or blank",
-               "values": {
-                   "1": "Debt-to-income ratio",
-                   "2": "Employment history",
-                   "3": "Credit history",
-                   "4": "Collateral",
-                   "5": "Insufficient cash (downpayment, closing costs)",
-                   "6": "Unverifiable information",
-                   "7": "Credit application incomplete",
-                   "8": "Mortgage insurance denied",
-                   "9": "Other"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": true,
+                   "canBeNA": false,
+                   "values": {
+                       "1": "Debt-to-income ratio",
+                       "2": "Employment history",
+                       "3": "Credit history",
+                       "4": "Collateral",
+                       "5": "Insufficient cash (downpayment, closing costs)",
+                       "6": "Unverifiable information",
+                       "7": "Credit application incomplete",
+                       "8": "Mortgage insurance denied",
+                       "9": "Other"
+                   }
                }
           },
           "rateSpread": {
@@ -848,10 +969,12 @@
                "end": "108",
                "length": "5",
                "dataType": "AN",
-               "format": "percent",
-               "canBeBlank": false,
-               "canBeNA": true,
-               "description": "Enter the rate spread to two decimal places. Include the decimal point and any leading or trailing zeros or NA left-justified"
+               "description": "Enter the rate spread to two decimal places. Include the decimal point and any leading or trailing zeros or NA left-justified",
+               "validation": {
+                   "type": "percent",
+                   "canBeBlank": false,
+                   "canBeNA": true
+               }
           },
           "hoepaStatus": {
                "label": "HOEPA Status",
@@ -859,13 +982,15 @@
                "end": "109",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1 or 2",
-               "values": {
-                    "1": "HOEPA loan",
-                    "2": "Not a HOEPA loan"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                        "1": "HOEPA loan",
+                        "2": "Not a HOEPA loan"
+                   }
                }
           },
           "lienStatus": {
@@ -874,15 +999,17 @@
                "end": "110",
                "length": "1",
                "dataType": "N",
-               "format": "number",
-               "canBeBlank": false,
-               "canBeNA": false,
                "description": "Values are 1, 2, 3, or 4",
-               "values": {
-                    "1": "Secured by a first lien",
-                    "2": "Secured by a subordinate lien",
-                    "3": "Not secured by a lien",
-                    "4": "Not applicable (purchased loans)"
+               "validation": {
+                   "type": "number",
+                   "canBeBlank": false,
+                   "canBeNA": false,
+                   "values": {
+                        "1": "Secured by a first lien",
+                        "2": "Secured by a subordinate lien",
+                        "3": "Not secured by a lien",
+                        "4": "Not applicable (purchased loans)"
+                   }
                }
           },
           "filler": {
@@ -891,9 +1018,11 @@
                "end": "380",
                "length": "270",
                "dataType": "AN",
-               "canBeBlank": true,
-               "canBeNA": false,
-               "description": "Blank"
+               "description": "Blank",
+               "validation": {
+                   "canBeBlank": true,
+                   "canBeNA": false
+               }
           }
      }
 }

--- a/2014/data_file_specification.json
+++ b/2014/data_file_specification.json
@@ -390,7 +390,7 @@
                "end": "54",
                "length": "5",
                "dataType": "N",
-               "format": "currency",
+               "format": "currency,thousands",
                "canBeBlank": false,
                "canBeNA": false,
                "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas"
@@ -748,7 +748,7 @@
                "end": "99",
                "length": "4",
                "dataType": "AN",
-               "format": "currency",
+               "format": "currency,thousands",
                "canBeBlank": false,
                "canBeNA": true,
                "description": "Report in thousands, round to the nearest thousand with leading zeros and without commas or NA left-justified"

--- a/2014/data_file_specification.json
+++ b/2014/data_file_specification.json
@@ -1,6 +1,7 @@
 {
      "metadata": {
           "src": "http://www.ffiec.gov/hmda/pdf/spec2014.pdf",
+          "values": "https://www.ffiec.gov/hmda/pdf/edit2014.pdf#page=7",
           "year": "2014"
      },
      "transmittalSheet": {

--- a/index.js
+++ b/index.js
@@ -114,6 +114,25 @@ var SpecAPI = function() {
     };
 
     /**
+     * Get a property from the defined file specification for the year.
+     * @param  {string} year     The {@link SpecAPI#getValidYears|year} for the edits
+     * @param  {string} scope    The {@link SpecAPI#getValidObjectTypes|scope} for the edits
+     * @param  {string} property The property
+     * @return {object}          Object defining the property within file specification
+     */
+    this.getFileSpecProperty = function(year, scope, property) {
+        var spec = this.getFileSpec(year);
+
+        if (scope === 'ts' && spec && spec.transmittalSheet[property]) {
+            return spec.transmittalSheet[property];
+        } else if (scope === 'lar' && spec && spec.loanApplicationRegister[property]) {
+            return spec.loanApplicationRegister[property];
+        }
+
+        return null;
+    };
+
+    /**
      * Gets the defined edits for the chosen year, scope, and edit type
      * @param  {string} year       The {@link SpecAPI#getValidYears|year} for the edits
      * @param  {string} scope      The {@link SpecAPI#getValidObjectTypes|scope} for the edits

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -38,9 +38,41 @@ describe('getFileSpec', function() {
         done();
     });
 
-    it('should return an empty object for an invalid year', function(done) {
+    it('should return null for an invalid year', function(done) {
         var spec = specAPI.getFileSpec('2000');
         expect(spec).to.be.null();
+        done();
+    });
+});
+
+describe('getFileSpecProperty', function() {
+    it('should return the transmittalSheet property from the spec for a given year', function(done) {
+        var prop = specAPI.getFileSpecProperty('2013', 'ts', 'recordID');
+        expect(prop.label).to.be('Record Identifier');
+        done();
+    });
+
+    it('should return the loanApplicationRegister property from the spec for a given year', function(done) {
+        var prop = specAPI.getFileSpecProperty('2013', 'lar', 'recordID');
+        expect(prop.label).to.be('Record Identifier');
+        done();
+    });
+
+    it('should return null for an invalid year', function(done) {
+        var prop = specAPI.getFileSpecProperty('2000', 'ts', 'recordID');
+        expect(prop).to.be.null();
+        done();
+    });
+
+    it('should return null for an invalid scope', function(done) {
+        var prop = specAPI.getFileSpecProperty('2013', 'hmdaFile', 'recordID');
+        expect(prop).to.be.null();
+        done();
+    });
+
+    it('should return null for an invalid property', function(done) {
+        var prop = specAPI.getFileSpecProperty('2013', 'ts', 'recordId');
+        expect(prop).to.be.null();
         done();
     });
 });
@@ -52,7 +84,7 @@ describe('getEdits', function() {
         done();
     });
 
-    it('should return an empty list for an invalid year, editType, objectType combo', function(done) {
+    it('should return null for an invalid year, editType, objectType combo', function(done) {
         var edits = specAPI.getEdits('2013', 'hmda', 'validity');
         expect(edits).to.be.null();
         done();


### PR DESCRIPTION
Do not merge without signoff from @feomike and/or @debseidner.

Added additional information to the spec so that a consumer of the JSON file can determine how submitted date should be formatted (via `format`), if a value can be blank (via `canBeBlank`) and if a value can be marked as NA - Not Applicable (via `canBeNA`).

For the most part I think this PR adds some useful info to the existing spec. One place where I'm still not sure if I'm getting it right is with describing currencies. See my other comment for my justification on why I went the direction I did.