### PR TITLE
S270 refactor

### DIFF
--- a/2013/hmda-syntactical.json
+++ b/2013/hmda-syntactical.json
@@ -10,6 +10,16 @@
         }
     },
     {
+        "id": "S270",
+        "description": "Century (CC) and Year (YY) of action taken date must = activity century/year (CCYY) for period being processed.",
+        "explanation": "Century and/or year for action taken date does not match activity century/year.",
+        "rule": {
+            "property": "hmdaFile",
+            "condition": "call",
+            "function": "isActionDateInActivityYear"
+        }
+    },
+    {
         "id": "S011",
         "description": "The HMDA file must contain at least one loan/application record (record identifier = 2).",
         "explanation": "File does not contain at least one loan/application record (record identifier = 2).",

--- a/2013/lar-syntactical.json
+++ b/2013/lar-syntactical.json
@@ -8,16 +8,5 @@
             "condition": "matches_regex",
             "value": "^(?!0{25}$).{25}$"
         }
-    },
-    {
-        "id": "S270",
-        "description": "Century (CC) and Year (YY) of action taken date must = activity century/year (CCYY) for period being processed.",
-        "explanation": "Century and/or year for action taken date does not match activity century/year.",
-        "rule": {
-            "property": "actionDate",
-            "condition": "call",
-            "function": "isActionDateInActivityYear",
-            "args": ["actionDate", "hmdaFile.transmittalSheet.activityYear"]
-        }
     }
 ]

--- a/2014/hmda-syntactical.json
+++ b/2014/hmda-syntactical.json
@@ -10,6 +10,16 @@
         }
     },
     {
+        "id": "S270",
+        "description": "Century (CC) and Year (YY) of action taken date must = activity century/year (CCYY) for period being processed.",
+        "explanation": "Century and/or year for action taken date does not match activity century/year.",
+        "rule": {
+            "property": "hmdaFile",
+            "condition": "call",
+            "function": "isActionDateInActivityYear"
+        }
+    },
+    {
         "id": "S011",
         "description": "The HMDA file must contain at least one loan/application record (record identifier = 2).",
         "explanation": "File does not contain at least one loan/application record (record identifier = 2).",

--- a/2014/lar-syntactical.json
+++ b/2014/lar-syntactical.json
@@ -8,16 +8,5 @@
             "condition": "matches_regex",
             "value": "^(?!0{25}$).{25}$"
         }
-    },
-    {
-        "id": "S270",
-        "description": "Century (CC) and Year (YY) of action taken date must = activity century/year (CCYY) for period being processed.",
-        "explanation": "Century and/or year for action taken date does not match activity century/year.",
-        "rule": {
-            "property": "actionDate",
-            "condition": "call",
-            "function": "isActionDateInActivityYear",
-            "args": ["actionDate", "hmdaFile.transmittalSheet.activityYear"]
-        }
     }
 ]


### PR DESCRIPTION
Move S270 to hmda-syntactical and refactor its method to use the entire hmdaFile rather than running per lar. For cfpb/hmda-pilot#326