### PR TITLE
Fix the regex being used for S205. 

### DIFF
--- a/2013/lar-syntactical.json
+++ b/2013/lar-syntactical.json
@@ -6,7 +6,7 @@
         "rule": {
             "property": "loanNumber",
             "condition": "matches_regex",
-            "value": "^(?!0{25}$).{25}$"
+            "value": "^(?!0{1,}$).{1,}$"
         }
     }
 ]

--- a/2014/lar-syntactical.json
+++ b/2014/lar-syntactical.json
@@ -6,7 +6,7 @@
         "rule": {
             "property": "loanNumber",
             "condition": "matches_regex",
-            "value": "^(?!0{25}$).{25}$"
+            "value": "^(?!0{1,}$).{1,}$"
         }
     }
 ]

--- a/nprm/lar-syntactical.json
+++ b/nprm/lar-syntactical.json
@@ -6,7 +6,7 @@
         "rule": {
             "property": "universalLoanID",
             "condition": "matches_regex",
-            "value": "^(?!0{25}$).{25}$"
+            "value": "^(?!0{1,}$).{1,}$"
         }
     }
 ]


### PR DESCRIPTION
Fixes cfpb/hmda-pilot#410. Don't force 25 characters to be present.
